### PR TITLE
Add App Library Sync Support

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -40,6 +40,7 @@ fuse.fuse_python_api = (0, 2)
 
 
 ROOT_DRIVEWSID = "FOLDER::com.apple.CloudDocs::root"
+DIRECTORY_NODE_TYPES = {"folder", "app_library"}
 
 
 class Stat(fuse.Stat):
@@ -560,7 +561,10 @@ class LocalMirror:
         return local
 
     def ensure_dir(self, path):
-        os.makedirs(self.local_path(path), exist_ok=True)
+        local = self.local_path(path)
+        if os.path.exists(local) and not os.path.isdir(local):
+            os.unlink(local)
+        os.makedirs(local, exist_ok=True)
 
     def ensure_parent(self, path):
         parent = os.path.dirname(path) or "/"
@@ -759,8 +763,8 @@ class ICloudSyncEngine:
             path = entry["path"]
             if entry["tombstone"]:
                 continue
-            if entry["type"] == "folder":
-                if not self.mirror.exists(path):
+            if self._is_directory_type(entry["type"]):
+                if not self.mirror.is_dir(path):
                     self.mirror.ensure_dir(path)
                     recreated_dirs += 1
                 continue
@@ -807,6 +811,9 @@ class ICloudSyncEngine:
             recreated_dirs,
             missing_files,
         )
+
+    def _is_directory_type(self, node_type):
+        return (node_type or "").lower() in DIRECTORY_NODE_TYPES
 
     def ensure_local_file(self, path):
         entry = self.state.get_entry(path)
@@ -886,7 +893,7 @@ class ICloudSyncEngine:
                 child_path = "/" + child.name if path == "/" else path.rstrip("/") + "/" + child.name
                 meta = self._node_to_meta(child, child_path)
                 snapshot[meta["remote_drivewsid"]] = meta
-                if meta["type"] == "folder":
+                if self._is_directory_type(meta["type"]):
                     queue.append((child, child_path))
 
             now = time.time()
@@ -949,7 +956,7 @@ class ICloudSyncEngine:
             drivewsid=meta.get("remote_drivewsid"),
             size=meta.get("size"),
         )
-        if meta["type"] == "folder":
+        if self._is_directory_type(meta["type"]):
             self.mirror.ensure_dir(local_path)
             hydrated = True
         else:
@@ -980,7 +987,7 @@ class ICloudSyncEngine:
             self.state.rename_tree(oldpath, newpath, root_dirty=False, update_synced=True)
             entry = self.state.get_entry(newpath)
 
-        if meta["type"] == "folder":
+        if self._is_directory_type(meta["type"]):
             self.mirror.ensure_dir(newpath)
             self.state.upsert_entry(
                 {
@@ -1368,7 +1375,7 @@ class ICloudSyncEngine:
     def _node_to_meta(self, node, path):
         data = node.data
         node_type = data.get("type", "FILE").lower()
-        if node_type == "folder":
+        if self._is_directory_type(node_type):
             size = 0
         else:
             size = int(data.get("size", 0) or 0)
@@ -1541,8 +1548,9 @@ class ICloudFS(Fuse):
             return attrs
 
         if entry and not entry["tombstone"]:
-            attrs.st_mode = (stat.S_IFDIR | 0o755) if entry["type"] == "folder" else (stat.S_IFREG | 0o644)
-            attrs.st_nlink = 2 if entry["type"] == "folder" else 1
+            is_directory = self.sync_engine._is_directory_type(entry["type"])
+            attrs.st_mode = (stat.S_IFDIR | 0o755) if is_directory else (stat.S_IFREG | 0o644)
+            attrs.st_nlink = 2 if is_directory else 1
             attrs.st_size = entry["size"]
             attrs.st_ctime = entry["mtime"] or now
             attrs.st_mtime = entry["mtime"] or now

--- a/test_driver.py
+++ b/test_driver.py
@@ -26,6 +26,13 @@ class DriverStateTests(unittest.TestCase):
         self.mirror.truncate("/docs/a.txt", 2)
         self.assertEqual(self.mirror.read("/docs/a.txt", 10, 0), b"he")
 
+    def test_ensure_dir_replaces_file_placeholder(self):
+        self.mirror.create_file("/Obsidian")
+
+        self.mirror.ensure_dir("/Obsidian")
+
+        self.assertTrue(self.mirror.is_dir("/Obsidian"))
+
     def test_rename_tree_preserves_old_synced_paths_for_local_rename(self):
         self.state.upsert_entry(
             {
@@ -153,6 +160,29 @@ class DriverStateTests(unittest.TestCase):
 
         entry = self.state.get_entry("/docs/a.txt")
         self.assertEqual(entry["hydrated"], 0)
+
+    def test_reconcile_persistent_cache_replaces_app_library_placeholder(self):
+        self.state.upsert_entry(
+            {
+                "path": "/Obsidian",
+                "type": "app_library",
+                "parent_path": "/",
+                "remote_drivewsid": "folder-1",
+                "hydrated": True,
+                "dirty": False,
+                "tombstone": False,
+                "synced_path": "/Obsidian",
+            }
+        )
+        self.mirror.create_file("/Obsidian")
+
+        api = Mock()
+        api.drive.root = Mock()
+        engine = ICloudSyncEngine(api, self.mirror, self.state, Mock())
+
+        engine._reconcile_persistent_cache()
+
+        self.assertTrue(self.mirror.is_dir("/Obsidian"))
 
     def test_remote_shareid_round_trips_through_state(self):
         self.state.upsert_entry(
@@ -317,6 +347,60 @@ class SyncEngineStartupTests(unittest.TestCase):
         self.assertEqual(node.data["docwsid"], "doc-1")
         self.assertEqual(node.data["shareID"], shareid)
         self.assertEqual(node.data["size"], 5)
+
+    def test_crawl_descends_into_app_library_nodes(self):
+        note = Mock()
+        note.name = "vault.md"
+        note.data = {
+            "type": "FILE",
+            "drivewsid": "file-1",
+            "docwsid": "doc-1",
+            "etag": "etag-1",
+            "zone": "zone-1",
+            "size": 12,
+            "dateModified": "2026-04-06T00:00:00Z",
+        }
+        obsidian = Mock()
+        obsidian.name = "Obsidian"
+        obsidian.data = {
+            "type": "APP_LIBRARY",
+            "drivewsid": "folder-1",
+            "docwsid": "documents",
+            "etag": "etag-folder",
+            "zone": "zone-1",
+            "dateModified": "2026-04-06T00:00:00Z",
+        }
+        obsidian.get_children.return_value = [note]
+        root = Mock()
+        root.get_children.return_value = [obsidian]
+        self.engine.api.drive.root = root
+
+        snapshot = self.engine._crawl_remote_snapshot()
+
+        self.assertIn("folder-1", snapshot)
+        self.assertIn("file-1", snapshot)
+        self.assertEqual(snapshot["folder-1"]["path"], "/Obsidian")
+        self.assertEqual(snapshot["folder-1"]["type"], "app_library")
+        self.assertEqual(snapshot["file-1"]["path"], "/Obsidian/vault.md")
+
+    def test_materialize_remote_entry_treats_app_library_as_directory(self):
+        self.engine._materialize_remote_entry(
+            {
+                "path": "/Obsidian",
+                "type": "app_library",
+                "parent_path": "/",
+                "remote_drivewsid": "folder-1",
+                "remote_docwsid": "documents",
+                "remote_etag": "etag-folder",
+                "remote_zone": "zone-1",
+                "size": 0,
+                "mtime": 123,
+            }
+        )
+
+        self.assertTrue(self.mirror.is_dir("/Obsidian"))
+        entry = self.state.get_entry("/Obsidian")
+        self.assertEqual(entry["hydrated"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Treat iCloud `app_library` nodes like folders so app-managed libraries such as Obsidian sync correctly on Linux.

## What changed
- recognize `app_library` entries as directories during remote crawl, cache reconciliation, and materialization
- replace stale file placeholders with directories when an app library exists at that path
- add test coverage for crawl, cache recovery, and directory materialization behavior

## Why
On Apple platforms, app libraries are browsable like normal folders. This makes the Linux sync behavior match that expectation and allows files inside those libraries to be discovered and synced.