### PR TITLE
Stream file transfers

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -15,9 +15,9 @@ import sys
 import tempfile
 import threading
 import time
+from contextlib import closing
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
-from io import BytesIO
 
 import fuse
 import yaml
@@ -40,6 +40,7 @@ fuse.fuse_python_api = (0, 2)
 
 
 ROOT_DRIVEWSID = "FOLDER::com.apple.CloudDocs::root"
+IO_CHUNK_SIZE = 1024 * 1024
 
 
 class Stat(fuse.Stat):
@@ -85,6 +86,15 @@ def sha256_file(path):
 
 def row_to_dict(row):
     return dict(row) if row is not None else None
+
+
+class NamedFileStream:
+    def __init__(self, handle, name):
+        self._handle = handle
+        self.name = name
+
+    def __getattr__(self, attr):
+        return getattr(self._handle, attr)
 
 
 class SyncState:
@@ -589,6 +599,20 @@ class LocalMirror:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
 
+    def write_atomic_stream(self, path, source, mtime=None, chunk_size=IO_CHUNK_SIZE):
+        self.ensure_parent(path)
+        local = self.local_path(path)
+        fd, tmp_path = tempfile.mkstemp(dir=self.tmp_dir)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                shutil.copyfileobj(source, handle, length=chunk_size)
+            os.replace(tmp_path, local)
+            if mtime is not None:
+                os.utime(local, (mtime, mtime))
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
     def read(self, path, size, offset):
         local = self.local_path(path)
         with open(local, "rb") as handle:
@@ -856,8 +880,8 @@ class ICloudSyncEngine:
                     entry.get("size"),
                 )
                 node = self._node_from_entry(entry)
-                content = node.open(stream=True).raw.read()
-            self.mirror.write_atomic_bytes(path, content, entry["mtime"])
+                with closing(node.open(stream=True)) as response:
+                    self.mirror.write_atomic_stream(path, response.raw, entry["mtime"])
             stats = self.mirror.stat_local(path)
             checksum = self.mirror.file_sha256(path)
             self.state.mark_hydrated(path, checksum, stats.st_size, int(stats.st_mtime))
@@ -1279,9 +1303,9 @@ class ICloudSyncEngine:
                     pass
 
             with open(self.mirror.local_path(entry["path"]), "rb") as handle:
-                file_obj = BytesIO(handle.read())
-            file_obj.name = os.path.basename(entry["path"])
-            parent_node.upload(file_obj)
+                parent_node.upload(
+                    NamedFileStream(handle, os.path.basename(entry["path"]))
+                )
 
             meta = self._refresh_child_meta(os.path.dirname(entry["path"]) or "/", os.path.basename(entry["path"]))
             checksum = self.mirror.file_sha256(entry["path"])

--- a/test_driver.py
+++ b/test_driver.py
@@ -1,3 +1,4 @@
+import io
 import os
 import shutil
 import sqlite3
@@ -7,6 +8,13 @@ from unittest.mock import Mock
 
 from driver import ICloudSyncEngine, LocalMirror, SyncState
 from pyicloud.exceptions import PyiCloudAPIResponseException, PyiCloudFailedLoginException
+
+
+class NoUnboundedReadStream(io.BytesIO):
+    def read(self, size=-1):
+        if size is None or size < 0:
+            raise AssertionError("stream was read without a chunk size")
+        return super().read(size)
 
 
 class DriverStateTests(unittest.TestCase):
@@ -25,6 +33,13 @@ class DriverStateTests(unittest.TestCase):
 
         self.mirror.truncate("/docs/a.txt", 2)
         self.assertEqual(self.mirror.read("/docs/a.txt", 10, 0), b"he")
+
+    def test_write_atomic_stream_copies_in_chunks(self):
+        stream = NoUnboundedReadStream(b"streamed content")
+
+        self.mirror.write_atomic_stream("/docs/a.txt", stream)
+
+        self.assertEqual(self.mirror.read("/docs/a.txt", 100, 0), b"streamed content")
 
     def test_rename_tree_preserves_old_synced_paths_for_local_rename(self):
         self.state.upsert_entry(
@@ -317,6 +332,82 @@ class SyncEngineStartupTests(unittest.TestCase):
         self.assertEqual(node.data["docwsid"], "doc-1")
         self.assertEqual(node.data["shareID"], shareid)
         self.assertEqual(node.data["size"], 5)
+
+    def test_ensure_local_file_streams_remote_content_in_chunks(self):
+        self.state.upsert_entry(
+            {
+                "path": "/docs/a.txt",
+                "type": "file",
+                "parent_path": "/docs",
+                "remote_drivewsid": "file-1",
+                "remote_docwsid": "doc-1",
+                "remote_zone": "zone-1",
+                "size": 16,
+                "mtime": 123,
+                "hydrated": False,
+                "dirty": False,
+                "tombstone": False,
+                "synced_path": "/docs/a.txt",
+            }
+        )
+        self.mirror.ensure_dir("/docs")
+        response = Mock()
+        response.raw = NoUnboundedReadStream(b"chunked download")
+        response.close = Mock()
+        node = Mock()
+        node.open.return_value = response
+        self.engine._node_from_entry = Mock(return_value=node)
+
+        self.engine.ensure_local_file("/docs/a.txt")
+
+        self.assertEqual(self.mirror.read("/docs/a.txt", 100, 0), b"chunked download")
+        response.close.assert_called_once()
+
+    def test_sync_file_uploads_stream_without_buffering_entire_file(self):
+        self.mirror.create_file("/docs/a.txt")
+        self.mirror.write("/docs/a.txt", b"hello world", 0)
+        self.state.upsert_entry(
+            {
+                "path": "/docs/a.txt",
+                "type": "file",
+                "parent_path": "/docs",
+                "remote_drivewsid": None,
+                "hydrated": True,
+                "dirty": True,
+                "tombstone": False,
+                "synced_path": "/docs/a.txt",
+            }
+        )
+        upload_state = {}
+
+        def capture_upload(stream):
+            upload_state["class_name"] = stream.__class__.__name__
+            upload_state["name"] = stream.name
+            upload_state["prefix"] = stream.read(5)
+
+        parent_node = Mock()
+        parent_node.upload.side_effect = capture_upload
+        self.engine._ensure_remote_parent = Mock(return_value=parent_node)
+        self.engine.ensure_local_file = Mock()
+        self.engine._refresh_child_meta = Mock(
+            return_value={
+                "path": "/docs/a.txt",
+                "type": "file",
+                "parent_path": "/docs",
+                "remote_drivewsid": "file-1",
+                "remote_docwsid": "doc-1",
+                "remote_etag": "etag-1",
+                "remote_zone": "zone-1",
+                "size": 11,
+                "mtime": 123,
+            }
+        )
+
+        self.engine._sync_file(self.state.get_entry("/docs/a.txt"))
+
+        self.assertEqual(upload_state["class_name"], "NamedFileStream")
+        self.assertEqual(upload_state["name"], "a.txt")
+        self.assertEqual(upload_state["prefix"], b"hello")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Stream downloads and uploads instead of buffering whole files in memory, which makes large transfers safer and more efficient.

## What changed
- add chunked mirror writes for streamed file content
- hydrate remote files by copying from the HTTP response stream instead of reading the full payload at once
- upload local files through a named stream wrapper so the remote API still receives a filename without preloading the file into memory
- add tests covering chunked download and upload behavior

## Why
The previous implementation loaded full file contents into memory for both hydration and upload. Streaming keeps memory usage bounded and better matches large-file sync workloads.