### PR TITLE
Fix HTTP 421 partition sharding and add trust-token auth mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Created by venv; see https://docs.python.org/3/library/venv.html
 sample-*.py
 samples/
-__pycache__/
+__pycache__/*.bak

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # icloud-linux
 
-Mount iCloud Drive on Linux as a fast local-first FUSE filesystem with persistent caching, background hydration, and bidirectional sync.
+Mount iCloud Drive on Linux as a fast local-first FUSE filesystem with persistent caching, selective hydration, and on-demand sync.
 
 ## What This Is
 
@@ -9,10 +9,10 @@ Mount iCloud Drive on Linux as a fast local-first FUSE filesystem with persisten
 It is designed to feel much more local than a naive network mount:
 
 - folders and filenames are cached on disk
-- file contents are downloaded into a local mirror
+- file contents are downloaded into a local mirror on demand or in the background
 - reads usually come from local storage, not from iCloud on every access
-- local changes are written immediately and synced back in the background
-- remote changes are pulled in by a real sync engine
+- local changes are written immediately and synced back on the next sync pass
+- remote changes are pulled in by the sync engine on demand or on a timer
 
 In practice, that means `find`, editors, shells, and normal file browsing work against a persistent local cache instead of blocking on iCloud for every operation.
 
@@ -21,8 +21,8 @@ In practice, that means `find`, editors, shells, and normal file browsing work a
 There are three main pieces:
 
 - Metadata crawl: the first run scans your iCloud Drive and builds a local index.
-- Background hydration: after metadata is known, file contents are downloaded into the local cache.
-- Sync engine: local edits upload in the background and remote changes are refreshed on a timer.
+- Hydration: file contents are downloaded into the local cache — either on demand when a file is opened (lazy mode) or proactively in the background (background mode).
+- Sync engine: local edits upload and remote changes are refreshed either automatically on a timer or on demand via `icloudctl sync`.
 
 Important behavior:
 
@@ -31,6 +31,7 @@ Important behavior:
 - If you open a file before it has finished hydrating, that file is downloaded first and then served locally.
 - Failed warmup downloads are retried automatically with backoff.
 - If a path changed both locally and remotely, the local version is preserved as a conflict copy instead of being silently overwritten.
+- With `auto_sync: false`, the driver starts and mounts immediately without spawning background polling threads. Run `icloudctl sync` when you want a fresh pull from iCloud.
 
 ## Who This Is For
 
@@ -39,7 +40,8 @@ This project is for people who want:
 - a normal folder they can browse on Linux
 - Apple ID + 2FA support
 - a persistent local cache
-- real background syncing instead of only on-demand reads
+- control over which folders are hydrated vs stub-only
+- on-demand syncing instead of constant background polling
 
 If you want a quick setup and do not care about the internal details, use `./icloudctl quickstart`.
 
@@ -68,7 +70,7 @@ sudo dnf install python3-devel fuse fuse-libs fuse-devel gcc make
 ## Fast Setup
 
 ```bash
-git clone https://github.com/ismaeelakram/icloud-linux.git
+git clone https://github.com/mslaughter21228/icloud-linux.git
 cd icloud-linux
 ./icloudctl quickstart ~/iCloud
 ```
@@ -111,6 +113,20 @@ If Apple expires your session, run:
 ./icloudctl restart
 ```
 
+### iOS 26 Beta 2FA Workaround
+
+iOS 26 beta may deliver a push notification popup instead of a numeric 2FA code. If this happens, use the `--force-sms` flag to bypass the push path and request an SMS code directly:
+
+```bash
+./icloudctl auth --force-sms
+```
+
+Use `--debug` to see Apple's reported auth mode and diagnose delivery issues:
+
+```bash
+./icloudctl auth --debug
+```
+
 ## Everyday Commands
 
 ```bash
@@ -120,6 +136,8 @@ If Apple expires your session, run:
 ./icloudctl status
 ./icloudctl logs
 ./icloudctl doctor
+./icloudctl hydrate [--dry-run] [--verbose]
+./icloudctl sync [--timeout SECONDS] [--quiet]
 ./icloudctl clear-cache
 ./icloudctl uninstall
 ```
@@ -132,6 +150,8 @@ What they do:
 - `status`: shows whether the service is running
 - `logs`: tails the service logs
 - `doctor`: checks common setup issues
+- `hydrate`: blocks until all eligible files (per `sync_paths` / `exclude_paths`) are fully downloaded locally. Use this before copying files to ensure nothing triggers a mid-copy download. `--dry-run` shows what would be downloaded without actually downloading.
+- `sync`: triggers an on-demand remote metadata sync in the running driver (sends SIGUSR1, waits for completion). Useful when `auto_sync: false` is set.
 - `clear-cache`: deletes the local mirror and sync database, then rebuilds them on next start
 - `uninstall`: removes the generated user service
 
@@ -141,15 +161,65 @@ On the first run:
 
 - the service crawls your iCloud Drive metadata
 - it mounts the folder
-- it starts downloading file contents into the local cache in the background
+- if `warmup_mode: background`, it starts downloading file contents into the local cache
+- if `warmup_mode: lazy`, file contents download only when each file is first opened
 
 On later runs:
 
 - it reuses the cache stored on disk
-- it refreshes remote metadata in the background
-- it continues hydrating anything still missing
+- if `auto_sync: true`, it refreshes remote metadata and uploads local changes on a timer
+- if `auto_sync: false`, it mounts immediately with no background polling; run `icloudctl sync` on demand
 
-Local file writes are committed to the mirror immediately and uploaded by the sync engine in the background.
+## Controlling What Gets Hydrated
+
+By default all of iCloud Drive is indexed (stubs created everywhere), but you can restrict which paths have their file contents downloaded.
+
+**`sync_paths`** — allow-list. Only paths in this list will have file contents downloaded. Everything else is stubs only.
+
+**`exclude_paths`** — deny-list. Paths matching these prefixes are never hydrated, even if they fall under a `sync_path`. The deny-list is evaluated first.
+
+Example config:
+
+```yaml
+# Only hydrate /Downloads
+sync_paths:
+  - /Downloads
+
+# But skip this large subfolder for now
+exclude_paths:
+  - /Downloads/Michael Priority
+```
+
+With this config:
+- `/Downloads/*` → file contents downloaded
+- `/Downloads/Michael Priority/*` → stubs only, no download
+- Everything else on iCloud → stubs only
+
+When you're ready to hydrate an excluded folder, remove it from `exclude_paths` and restart the service.
+
+## Auto-Sync vs On-Demand Sync
+
+**`auto_sync: true`** (default) — background threads poll iCloud on the configured `upload_interval_seconds` and `remote_refresh_interval_seconds` schedules. Good for setups where files change frequently.
+
+**`auto_sync: false`** — no polling threads start. The driver mounts and waits. Use `icloudctl sync` to pull the latest remote changes when you need them. Good for low-churn libraries where constant polling is wasteful and you want predictable resource usage.
+
+When `auto_sync: false`, the recommended workflow is:
+
+```bash
+icloudctl sync          # pull latest metadata from iCloud
+icloudctl hydrate       # download file contents for all eligible paths
+# now copy from mirror: ~/.cache/icloud-linux/mirror/Downloads/
+```
+
+## Copying Files to Another Location
+
+Once files are hydrated, copy from the local mirror rather than from the FUSE mount:
+
+```bash
+cp -r ~/.cache/icloud-linux/mirror/Downloads/ ~/Desktop/intake/
+```
+
+The mirror is a plain directory on disk — reads are instant, no network involved. Copying from the FUSE mount works too but may trigger downloads for any files not yet hydrated.
 
 ## Local Cache And Sync State
 
@@ -163,17 +233,18 @@ The project keeps its local state here:
 - Local mirror: `~/.cache/icloud-linux/mirror`
 - Sync state database: `~/.cache/icloud-linux/state.sqlite3`
 - Logs: `~/.local/state/icloud-linux/icloud.log`
+- On-demand sync marker: `~/.local/state/icloud-linux/sync_done`
 
-## What “Sync Engine” Means Here
+## What "Sync Engine" Means Here
 
 This repo is not just a read-only mount and it is not only a foreground downloader.
 
 The sync engine:
 
 - tracks local dirty files and directories
-- uploads local changes on a timer
-- refreshes remote metadata on a timer
-- hydrates missing file contents in the background
+- uploads local changes (when `auto_sync: true` or on `icloudctl sync`)
+- refreshes remote metadata (when `auto_sync: true` or on `icloudctl sync`)
+- hydrates missing file contents on demand or in the background
 - preserves local conflict copies when local and remote diverge
 
 That makes it closer to a real cached sync client than a simple network filesystem wrapper.
@@ -199,6 +270,15 @@ Run:
 ./icloudctl restart
 ```
 
+### Service starts but auth fails silently (unauthenticated mode)
+
+When running under systemd (no TTY), a failed auth parks the service in unauthenticated mode instead of crashing — this prevents the service from crash-looping and triggering Apple's account lockout. You will see `UNAUTHENTICATED mode` in the logs. Fix by running:
+
+```bash
+./icloudctl auth
+./icloudctl restart
+```
+
 ### I want to rebuild everything locally
 
 Run:
@@ -215,7 +295,6 @@ After the service has had time to hydrate files:
 
 ```bash
 find ~/iCloud -type f | head
-rg --files ~/iCloud | head
 ```
 
 You can watch logs in another terminal:
@@ -224,10 +303,19 @@ You can watch logs in another terminal:
 ./icloudctl logs
 ```
 
-Normal activity should mostly look like background crawl, hydration, and sync logs rather than a separate remote fetch for every file operation.
+Normal activity with `auto_sync: false` will show the reconcile pass at startup and then go quiet until you run `icloudctl sync`.
+
+### I want to check hydration progress
+
+```bash
+./icloudctl hydrate --dry-run
+```
+
+This reports how many files are already local vs need downloading, without downloading anything.
 
 ## Notes
 
 - Warmup downloads are intentionally conservative because iCloud file downloads are sensitive to aggressive parallelism.
 - The generated systemd unit is created by `./icloudctl`; the repo does not rely on checked-in service files anymore.
 - This project currently targets a user-level systemd service, not a system-wide root service.
+- When `auto_sync: false`, the SIGUSR1 signal triggers a one-shot sync in the background; `icloudctl sync` handles sending that signal and waiting for completion.

--- a/auth.py
+++ b/auth.py
@@ -2,15 +2,23 @@
 """
 auth.py — icloud-linux one-time authentication bootstrap.
 
-Two modes:
-  1. Normal: prompts for 2FA code (push to Apple device)
-  2. Trust-token mode: supply --trust-token <value> extracted from a browser
-     session at icloud.com to bypass the 2FA push entirely.
+Modes:
+  1. Normal (default): triggers Apple's preferred 2FA delivery (push to device)
+  2. --force-sms: bypasses push delivery and forces an SMS code to your trusted
+     phone number — useful when iOS beta push doesn't show a numeric code
+  3. --trust-token <value>: inject a browser trust-token extracted from
+     icloud.com DevTools → Application → Cookies → X-APPLE-WEBAUTH-HSA-TRUST
 
 Usage:
   ./icloudctl auth
   .venv/bin/python auth.py ~/.config/icloud-linux/config.yaml
+  .venv/bin/python auth.py ~/.config/icloud-linux/config.yaml --force-sms
   .venv/bin/python auth.py ~/.config/icloud-linux/config.yaml --trust-token <TOKEN>
+
+iOS 26 beta workaround:
+  If Apple is sending a push popup instead of a numeric code, use --force-sms.
+  This PUTs directly to /appleauth/auth/verify/phone with mode=sms, bypassing
+  the push/trusted-device bridge that iOS 26 beta fails to complete.
 """
 import os
 import sys
@@ -37,17 +45,104 @@ def get_partition():
     return r.headers.get("x-apple-user-partition")
 
 
+def print_auth_diagnostics(api):
+    """Print debug info about what auth mode Apple is reporting."""
+    print("\n--- Auth diagnostics ---")
+    auth_data = getattr(api, '_auth_data', {})
+    print(f"  mode (raw):            {auth_data.get('mode', '(not set)')}")
+    print(f"  two_factor_delivery:   {getattr(api, 'two_factor_delivery_method', '?')}")
+    print(f"  requires_2fa:          {api.requires_2fa}")
+    tp = api._trusted_phone_number() if hasattr(api, '_trusted_phone_number') else None
+    if tp:
+        print(f"  trusted_phone id:      {tp.device_id}")
+        print(f"  trusted_phone mode:    {tp.push_mode}")
+        print(f"  trusted_phone nonFTEU: {tp.non_fteu}")
+    else:
+        print("  trusted_phone:         (none found)")
+    supports_bridge = api._supports_trusted_device_bridge() if hasattr(api, '_supports_trusted_device_bridge') else '?'
+    can_sms = api._can_request_sms_2fa_code() if hasattr(api, '_can_request_sms_2fa_code') else '?'
+    print(f"  supports_bridge:       {supports_bridge}")
+    print(f"  can_request_sms:       {can_sms}")
+    print("------------------------\n")
+
+
+def do_sms_forced(api):
+    """Force SMS delivery regardless of what push_mode Apple reported.
+
+    iOS 26 beta reports push_mode='push' on the trusted phone number, which
+    makes _can_request_sms_2fa_code() return False even though the SMS endpoint
+    still works.  We call _request_sms_2fa_code() directly to bypass the guard.
+    """
+    print("\nForcing SMS delivery to your trusted phone number...")
+    try:
+        sent = api._request_sms_2fa_code()
+    except Exception as exc:
+        print(f"ERROR triggering SMS: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not sent:
+        print("Apple declined to send an SMS (no trusted phone number on the account?).", file=sys.stderr)
+        sys.exit(1)
+
+    print("SMS sent.  Check your phone for a 6-digit code.")
+    code = input("Enter 2FA code: ").strip()
+
+    # _validate_sms_code is the correct path when delivery mode is sms
+    try:
+        api._validate_sms_code(code)
+    except Exception as exc:
+        print(f"Code validation failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not api.is_trusted_session:
+        print("Trusting session...")
+        api.trust_session()
+
+
+def do_2fa(api):
+    """Standard 2FA: use Apple's preferred method (push or bridge), then accept code."""
+    print("\n2FA required.")
+    # Try to trigger whichever delivery Apple prefers for this account
+    try:
+        triggered = api.request_2fa_code()
+    except Exception as exc:
+        print(f"Warning: could not trigger 2FA delivery: {exc}", file=sys.stderr)
+        triggered = False
+
+    method = api.two_factor_delivery_method
+    if method == "trusted_device":
+        print("A 2FA prompt has been sent to your trusted Apple device.")
+        print("Tap Allow on your device, then enter the 6-digit code that appears.")
+    elif method == "sms":
+        print("A 2FA code has been sent via SMS to your trusted phone number.")
+    else:
+        print(f"2FA delivery mode: {method}")
+        print("Watch your iPhone/iPad for a popup or SMS with a 6-digit code.")
+        if not triggered:
+            print("\nHINT: If you see a push popup instead of a code, re-run with --force-sms")
+
+    code = input("\nEnter 2FA code: ").strip()
+    if not api.validate_2fa_code(code):
+        print("Invalid 2FA code.", file=sys.stderr)
+        sys.exit(1)
+    if not api.is_trusted_session:
+        print("Trusting session...")
+        api.trust_session()
+
+
 def main():
     args = sys.argv[1:]
     config_path = os.path.expanduser(
         args[0] if args and not args[0].startswith("--") else "~/.config/icloud-linux/config.yaml"
     )
 
+    force_sms = "--force-sms" in args
     trust_token = None
     if "--trust-token" in args:
         idx = args.index("--trust-token")
         if idx + 1 < len(args):
             trust_token = args[idx + 1]
+    debug = "--debug" in args
 
     cfg = load_config(config_path)
     username = cfg.get("username")
@@ -88,27 +183,31 @@ def main():
         try:
             api.authenticate(force_refresh=True)
         except PyiCloud2FARequiredException:
-            print("\n2FA required.")
-            print("Watch your iPhone or iPad for a system popup — tap Allow.")
-            print("A 6-digit code will appear on the device after you tap Allow.")
-            code = input("\nEnter 2FA code: ").strip()
-            if not api.validate_2fa_code(code):
-                print("Invalid 2FA code.", file=sys.stderr)
-                sys.exit(1)
-            if not api.is_trusted_session:
-                api.trust_session()
+            pass  # requires_2fa check below handles this
+
+    if debug:
+        print_auth_diagnostics(api)
+
+    # After authenticate(), requires_2fa may still be True even without exception
+    if api.requires_2fa:
+        if force_sms:
+            do_sms_forced(api)
+        else:
+            do_2fa(api)
 
     print(f"\nrequires_2fa:  {api.requires_2fa}")
     print(f"is_trusted:    {api.is_trusted_session}")
 
     if api.requires_2fa:
-        print("Authentication incomplete — still requires 2FA.", file=sys.stderr)
+        print("\nAuthentication incomplete — still requires 2FA.", file=sys.stderr)
+        print("If you saw a push popup instead of a numeric code, try:", file=sys.stderr)
+        print("  ./icloudctl auth --force-sms", file=sys.stderr)
         sys.exit(1)
 
     print("\nAUTH_OK")
     print(f"Session saved to: {cookie_dir}")
 
-    if "dsInfo" in api.data:
+    if hasattr(api, 'data') and api.data and "dsInfo" in api.data:
         print(f"Authenticated as: {api.data['dsInfo'].get('appleId', '?')}")
 
 

--- a/auth.py
+++ b/auth.py
@@ -1,8 +1,23 @@
 #!/usr/bin/env python3
+"""
+auth.py — icloud-linux one-time authentication bootstrap.
+
+Two modes:
+  1. Normal: prompts for 2FA code (push to Apple device)
+  2. Trust-token mode: supply --trust-token <value> extracted from a browser
+     session at icloud.com to bypass the 2FA push entirely.
+
+Usage:
+  ./icloudctl auth
+  .venv/bin/python auth.py ~/.config/icloud-linux/config.yaml
+  .venv/bin/python auth.py ~/.config/icloud-linux/config.yaml --trust-token <TOKEN>
+"""
 import os
 import sys
 import yaml
+import requests
 from pyicloud import PyiCloudService
+from pyicloud.exceptions import PyiCloud2FARequiredException
 
 
 def load_config(path):
@@ -10,12 +25,31 @@ def load_config(path):
         return yaml.safe_load(f) or {}
 
 
-def main():
-    config_path = os.path.expanduser(
-        sys.argv[1] if len(sys.argv) > 1 else "~/.config/icloud-linux/config.yaml"
-    )
-    cfg = load_config(config_path)
+def get_partition():
+    """Detect Apple's account shard to avoid 421 errors."""
+    s = requests.Session()
+    s.headers.update({
+        "Origin": "https://www.icloud.com",
+        "Referer": "https://www.icloud.com/",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+    })
+    r = s.post("https://setup.icloud.com/setup/ws/1/validate", json={})
+    return r.headers.get("x-apple-user-partition")
 
+
+def main():
+    args = sys.argv[1:]
+    config_path = os.path.expanduser(
+        args[0] if args and not args[0].startswith("--") else "~/.config/icloud-linux/config.yaml"
+    )
+
+    trust_token = None
+    if "--trust-token" in args:
+        idx = args.index("--trust-token")
+        if idx + 1 < len(args):
+            trust_token = args[idx + 1]
+
+    cfg = load_config(config_path)
     username = cfg.get("username")
     password = cfg.get("password")
     cookie_dir = os.path.expanduser(
@@ -24,42 +58,58 @@ def main():
     os.makedirs(cookie_dir, exist_ok=True)
 
     if not username or not password:
-        print("Missing username/password in config", file=sys.stderr)
+        print("Missing username/password in config.", file=sys.stderr)
         sys.exit(1)
 
-    api = PyiCloudService(username, password, cookie_directory=cookie_dir)
+    print("Detecting Apple account partition...")
+    partition = get_partition()
+    if partition:
+        endpoint = f"https://p{partition}-setup.icloud.com/setup/ws/1"
+        print(f"Partition {partition} → {endpoint}")
+    else:
+        endpoint = None
+        print("Using default endpoint.")
+
+    api = PyiCloudService(
+        username, password,
+        cookie_directory=cookie_dir,
+        authenticate=False,
+    )
+    if endpoint:
+        api._setup_endpoint = endpoint
+
+    if trust_token:
+        # Browser trust-token mode: inject token and authenticate directly
+        print("Trust-token mode: injecting browser session token...")
+        api.session.data["trust_token"] = trust_token
+        api.authenticate(force_refresh=True)
+    else:
+        # Standard mode: authenticate and handle 2FA interactively
+        try:
+            api.authenticate(force_refresh=True)
+        except PyiCloud2FARequiredException:
+            print("\n2FA required.")
+            print("Watch your iPhone or iPad for a system popup — tap Allow.")
+            print("A 6-digit code will appear on the device after you tap Allow.")
+            code = input("\nEnter 2FA code: ").strip()
+            if not api.validate_2fa_code(code):
+                print("Invalid 2FA code.", file=sys.stderr)
+                sys.exit(1)
+            if not api.is_trusted_session:
+                api.trust_session()
+
+    print(f"\nrequires_2fa:  {api.requires_2fa}")
+    print(f"is_trusted:    {api.is_trusted_session}")
 
     if api.requires_2fa:
-        print("2FA required. Enter code from your Apple device.")
-        code = input("2FA code: ").strip()
-        if not api.validate_2fa_code(code):
-            print("Invalid 2FA code", file=sys.stderr)
-            sys.exit(1)
-        if not api.is_trusted_session:
-            api.trust_session()
-
-    if api.requires_2sa:
-        print("2SA required.")
-        devices = api.trusted_devices
-        for i, device in enumerate(devices):
-            label = device.get("deviceName") or f"SMS to {device.get('phoneNumber', 'unknown')}"
-            print(f"{i}: {label}")
-        idx = int(input("Select device index [0]: ").strip() or "0")
-        device = devices[idx]
-        if not api.send_verification_code(device):
-            print("Failed to send verification code", file=sys.stderr)
-            sys.exit(1)
-        code = input("Verification code: ").strip()
-        if not api.validate_verification_code(device, code):
-            print("Invalid verification code", file=sys.stderr)
-            sys.exit(1)
-
-    if api.requires_2fa or api.requires_2sa:
-        print("Authentication incomplete", file=sys.stderr)
+        print("Authentication incomplete — still requires 2FA.", file=sys.stderr)
         sys.exit(1)
 
-    print("AUTH_OK")
-    print(f"Cookie/session data stored under: {cookie_dir}")
+    print("\nAUTH_OK")
+    print(f"Session saved to: {cookie_dir}")
+
+    if "dsInfo" in api.data:
+        print(f"Authenticated as: {api.data['dsInfo'].get('appleId', '?')}")
 
 
 if __name__ == "__main__":

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,6 +29,20 @@ warmup_workers: 1
 # Persistent cookie/session directory used after one-time 2FA bootstrap
 cookie_dir: "~/.config/icloud-linux/cookies"
 
+# Paths to exclude from hydration (deny-list, evaluated before sync_paths).
+# Matching paths will have stubs created but file contents will never be
+# downloaded.  Useful for carving large subdirectories out of a sync_path.
+# Comment out or remove to hydrate everything under sync_paths.
+#
+# Example: hydrate all of /Downloads except the huge Michael Priority folder:
+#   sync_paths:
+#     - /Downloads
+#   exclude_paths:
+#     - /Downloads/Michael Priority
+#
+# exclude_paths:
+#   - /Downloads/Michael Priority
+
 # FUSE options
 fuse_options:
   allow_other: false  # Set to true to allow other users to access the mount

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,6 +43,15 @@ cookie_dir: "~/.config/icloud-linux/cookies"
 # exclude_paths:
 #   - /Downloads/Michael Priority
 
+# Auto-sync mode.
+# true (default)  — background threads poll iCloud on upload_interval_seconds
+#                   and remote_refresh_interval_seconds schedules automatically.
+# false           — background threads are NOT started.  The driver mounts and
+#                   waits; run 'icloudctl sync' to pull the latest remote
+#                   changes on demand.  Good for low-churn libraries where
+#                   constant polling is wasteful.
+auto_sync: true
+
 # FUSE options
 fuse_options:
   allow_other: false  # Set to true to allow other users to access the mount

--- a/driver.py
+++ b/driver.py
@@ -915,6 +915,21 @@ class ICloudSyncEngine:
                 meta = self._node_to_meta(child, child_path)
                 snapshot[meta["remote_drivewsid"]] = meta
                 if meta["type"] == "folder":
+                    # If sync_paths is set, only recurse into folders that are
+                    # on the path to or inside a sync_path. This avoids crawling
+                    # the entire iCloud Drive when only /Downloads is needed.
+                    if self.sync_paths is not None:
+                        should_recurse = False
+                        for sp in self.sync_paths:
+                            sp = sp.rstrip("/")
+                            cp = child_path.rstrip("/")
+                            # Recurse if child is a prefix of sync_path (ancestor)
+                            # or if child is inside sync_path (descendant)
+                            if sp.startswith(cp + "/") or sp == cp or cp.startswith(sp + "/"):
+                                should_recurse = True
+                                break
+                        if not should_recurse:
+                            continue
                     queue.append((child, child_path))
 
             now = time.time()

--- a/driver.py
+++ b/driver.py
@@ -672,6 +672,7 @@ class ICloudSyncEngine:
         warmup_workers=1,
         sync_paths=None,
         exclude_paths=None,
+        auto_sync=True,
     ):
         self.api = api
         self.mirror = mirror
@@ -682,6 +683,7 @@ class ICloudSyncEngine:
         self.upload_interval_seconds = upload_interval_seconds
         self.remote_refresh_interval_seconds = remote_refresh_interval_seconds
         self.warmup_workers = max(1, int(warmup_workers))
+        self.auto_sync = bool(auto_sync)
         # Normalise sync_paths: list of /-prefixed strings, or None = allow all
         if sync_paths:
             self.sync_paths = [p if p.startswith('/') else '/' + p for p in sync_paths]
@@ -727,7 +729,13 @@ class ICloudSyncEngine:
             self.initial_scan()
             if self.warmup_mode == "background":
                 self._schedule_all_unhydrated()
-        self._start_background_threads()
+        if self.auto_sync:
+            self._start_background_threads()
+        else:
+            self.logger.info(
+                "auto_sync disabled — background upload/refresh threads not started. "
+                "Use 'icloudctl sync' to trigger a one-shot refresh on demand."
+            )
 
     def _start_background_threads(self):
         upload_thread = threading.Thread(target=self._upload_loop, name="icloud-upload", daemon=True)
@@ -1576,6 +1584,7 @@ class ICloudFS(Fuse):
         warmup_workers,
         sync_paths=None,
         exclude_paths=None,
+        auto_sync=True,
     ):
         self.mirror = LocalMirror(cache_dir)
         state_path = os.path.join(cache_dir, "state.sqlite3")
@@ -1598,6 +1607,7 @@ class ICloudFS(Fuse):
             warmup_workers=warmup_workers,
             sync_paths=sync_paths,
             exclude_paths=exclude_paths,
+            auto_sync=auto_sync,
         )
         self.sync_engine.start()
 
@@ -2005,6 +2015,7 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
     warmup_workers = int(config.get("warmup_workers", 1))
     sync_paths = config.get("sync_paths", None)      # list of iCloud paths to hydrate, None=all
     exclude_paths = config.get("exclude_paths", None) # deny-list applied before sync_paths
+    auto_sync = bool(config.get("auto_sync", True))   # False = manual sync only via icloudctl sync
 
     # When running under systemd (no TTY) we never want a failed auth to crash
     # the process — that would trigger Restart=on-failure and hammer Apple's
@@ -2021,6 +2032,7 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
         warmup_workers,
         sync_paths=sync_paths,
         exclude_paths=exclude_paths,
+        auto_sync=auto_sync,
     )
 
     atexit.register(fs.shutdown)
@@ -2030,8 +2042,34 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
         fs.shutdown()
         raise SystemExit(0)
 
+    # SIGUSR1 — on-demand sync trigger (used by 'icloudctl sync')
+    # Runs a one-shot remote crawl + upload pass in a background thread so the
+    # signal handler returns immediately and FUSE keeps serving requests.
+    def handle_sigusr1(signum, frame):
+        if fs.sync_engine is None:
+            logger.warning("SIGUSR1: sync engine not running (unauthenticated?)")
+            return
+        logger.info("SIGUSR1: starting on-demand sync")
+
+        def _one_shot():
+            try:
+                fs.sync_engine.initial_scan()
+                logger.info("SIGUSR1: on-demand sync complete")
+            except Exception as exc:
+                logger.error("SIGUSR1: on-demand sync failed: %s", exc)
+            finally:
+                # Write a completion marker so icloudctl sync can detect done.
+                state_dir = os.path.expanduser("~/.local/state/icloud-linux")
+                os.makedirs(state_dir, exist_ok=True)
+                marker = os.path.join(state_dir, "sync_done")
+                with open(marker, "w") as fh:
+                    fh.write(str(time.time()))
+
+        threading.Thread(target=_one_shot, name="icloud-on-demand-sync", daemon=True).start()
+
     signal.signal(signal.SIGTERM, handle_shutdown)
     signal.signal(signal.SIGINT, handle_shutdown)
+    signal.signal(signal.SIGUSR1, handle_sigusr1)
 
     try:
         fs.main()

--- a/driver.py
+++ b/driver.py
@@ -900,12 +900,20 @@ class ICloudSyncEngine:
         started_at = time.time()
         last_progress_log = started_at
         scanned_folders = 0
+        _crawl_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="icloud-crawl")
+        FOLDER_TIMEOUT = 60  # seconds per folder before giving up
 
         while queue:
             node, path = queue.popleft()
             scanned_folders += 1
             try:
-                children = node.get_children(force=True)
+                future = _crawl_executor.submit(node.get_children, True)
+                children = future.result(timeout=FOLDER_TIMEOUT)
+            except TimeoutError:
+                self.logger.warning(
+                    "Timed out enumerating %s after %ss — skipping folder", path, FOLDER_TIMEOUT
+                )
+                continue
             except Exception as exc:
                 self.logger.error("Failed to enumerate %s: %s", path, exc)
                 continue

--- a/driver.py
+++ b/driver.py
@@ -776,8 +776,14 @@ class ICloudSyncEngine:
                 checksum = entry.get("local_sha256")
                 hydrated = bool(entry["hydrated"])
                 if entry["type"] == "file" and (hydrated or not entry["remote_drivewsid"]):
-                    checksum = self.mirror.file_sha256(path)
                     hydrated = True
+                    # Only recompute the SHA256 if size or mtime changed since
+                    # the last recorded sync — reading every file on startup is
+                    # the cause of the 4-minute / 11 GB memory blowup at boot.
+                    size_changed = stats.st_size != int(entry.get("size") or 0)
+                    mtime_changed = int(stats.st_mtime) != int(entry.get("mtime") or 0)
+                    if size_changed or mtime_changed or not checksum:
+                        checksum = self.mirror.file_sha256(path)
                 self.state.upsert_entry(
                     {
                         **entry,

--- a/driver.py
+++ b/driver.py
@@ -1456,7 +1456,15 @@ class ICloudFS(Fuse):
         if self.sync_engine is not None:
             self.sync_engine.shutdown()
 
-    def init_icloud(self, username, password, cache_dir, cookie_dir=None):
+    def init_icloud(self, username, password, cache_dir, cookie_dir=None, require_session=True):
+        """Initialise iCloud API connection.
+
+        If *require_session* is False (the default when called from the systemd
+        service path), an auth failure sets self.api = None and logs a clear
+        error rather than crashing the process.  The FUSE layer will return
+        EACCES for all operations until a session is restored via
+        './icloudctl auth' followed by './icloudctl restart'.
+        """
         self.username = username
         self.password = password
         self.cache_dir = cache_dir
@@ -1513,9 +1521,23 @@ class ICloudFS(Fuse):
 
             if self.api.requires_2fa or self.api.requires_2sa:
                 raise RuntimeError("Additional authentication still required after code verification.")
+
         except Exception as exc:
             self.logger.error("Failed to connect to iCloud: %s", exc)
-            raise
+            if require_session:
+                raise
+            # Non-fatal path: park in unauthenticated state.  The FUSE layer
+            # will return EACCES for all operations; the service stays up and
+            # won't trigger Apple's lockout by crash-looping.
+            self.logger.error(
+                "Service starting in UNAUTHENTICATED mode.  "
+                "Run './icloudctl auth' then './icloudctl restart' to restore access."
+            )
+            self.api = None
+
+    def _is_authenticated(self):
+        """Return True if a live iCloud session is available."""
+        return self.api is not None
 
     def init_local_cache(
         self,
@@ -1530,6 +1552,12 @@ class ICloudFS(Fuse):
         self.mirror = LocalMirror(cache_dir)
         state_path = os.path.join(cache_dir, "state.sqlite3")
         self.state = SyncState(state_path)
+        if not self._is_authenticated():
+            self.logger.warning(
+                "Skipping sync engine start — no iCloud session.  "
+                "FUSE will serve cached data read-only until re-authenticated."
+            )
+            return
         self.sync_engine = ICloudSyncEngine(
             self.api,
             self.mirror,
@@ -1605,6 +1633,14 @@ class ICloudFS(Fuse):
 
         entry = self.state.get_entry(path)
         if entry and entry["type"] == "file" and not entry["hydrated"] and not entry["dirty"]:
+            if not self._is_authenticated() or self.sync_engine is None:
+                # No session: serve what we have locally; remote files return EIO
+                if not self.mirror.exists(path):
+                    self.logger.warning(
+                        "Cannot hydrate %s: no iCloud session. Run './icloudctl auth' then restart.", path
+                    )
+                    return -errno.EIO
+                return 0
             try:
                 self.sync_engine.ensure_local_file(path)
             except Exception as exc:
@@ -1613,6 +1649,8 @@ class ICloudFS(Fuse):
         return 0
 
     def create(self, path, mode, flags=None):
+        if not self._is_authenticated():
+            return -errno.EACCES
         try:
             self.mirror.create_file(path)
             stats = self.mirror.stat_local(path)
@@ -1643,6 +1681,12 @@ class ICloudFS(Fuse):
 
         try:
             if not entry["hydrated"] and not entry["dirty"]:
+                if self.sync_engine is None:
+                    # No session — cannot hydrate; if placeholder exists it has no data
+                    self.logger.warning(
+                        "Cannot hydrate %s: no iCloud session. Run './icloudctl auth' then restart.", path
+                    )
+                    return -errno.EIO
                 self.sync_engine.ensure_local_file(path)
             self._log_file_op("read", path, level=logging.DEBUG, size=size, offset=offset)
             return self.mirror.read(path, size, offset)
@@ -1651,6 +1695,8 @@ class ICloudFS(Fuse):
             return -errno.EIO
 
     def write(self, path, buf, offset):
+        if not self._is_authenticated():
+            return -errno.EACCES
         entry = self.state.get_entry(path)
         if entry and not entry["hydrated"] and entry["remote_drivewsid"]:
             try:
@@ -1694,6 +1740,8 @@ class ICloudFS(Fuse):
         return 0
 
     def mkdir(self, path, mode):
+        if not self._is_authenticated():
+            return -errno.EACCES
         try:
             self.mirror.ensure_dir(path)
             stats = self.mirror.stat_local(path)
@@ -1718,6 +1766,8 @@ class ICloudFS(Fuse):
             return -errno.EIO
 
     def rmdir(self, path):
+        if not self._is_authenticated():
+            return -errno.EACCES
         entry = self.state.get_entry(path)
         if not entry:
             return -errno.ENOENT
@@ -1738,6 +1788,8 @@ class ICloudFS(Fuse):
             return -errno.EIO
 
     def unlink(self, path):
+        if not self._is_authenticated():
+            return -errno.EACCES
         entry = self.state.get_entry(path)
         if not entry:
             return -errno.ENOENT
@@ -1759,6 +1811,8 @@ class ICloudFS(Fuse):
             return -errno.EIO
 
     def rename(self, oldpath, newpath):
+        if not self._is_authenticated():
+            return -errno.EACCES
         entry = self.state.get_entry(oldpath)
         if not entry:
             return -errno.ENOENT
@@ -1782,6 +1836,8 @@ class ICloudFS(Fuse):
             return -errno.EIO
 
     def truncate(self, path, length):
+        if not self._is_authenticated():
+            return -errno.EACCES
         entry = self.state.get_entry(path)
         if entry and not entry["hydrated"] and entry["remote_drivewsid"]:
             try:
@@ -1920,7 +1976,12 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
     warmup_workers = int(config.get("warmup_workers", 1))
     sync_paths = config.get("sync_paths", None)  # list of iCloud paths to hydrate, None=all
 
-    fs.init_icloud(username, password, cache_dir, cookie_dir)
+    # When running under systemd (no TTY) we never want a failed auth to crash
+    # the process — that would trigger Restart=on-failure and hammer Apple's
+    # lockout threshold.  require_session=True is still the right default for
+    # interactive invocations (e.g. debugging from a terminal with -f).
+    interactive = sys.stdin.isatty()
+    fs.init_icloud(username, password, cache_dir, cookie_dir, require_session=interactive)
     fs.init_local_cache(
         cache_dir,
         warmup_mode,

--- a/driver.py
+++ b/driver.py
@@ -1446,7 +1446,19 @@ class ICloudFS(Fuse):
             os.makedirs(cookie_dir, exist_ok=True)
 
         try:
-            self.api = PyiCloudService(username, password, cookie_directory=cookie_dir)
+            # Resolve Apple account partition (fixes 421 redirect for non-default shards)
+            import requests as _req
+            _r = _req.post("https://setup.icloud.com/setup/ws/1/validate", json={})
+            _partition = _r.headers.get("x-apple-user-partition")
+
+            self.api = PyiCloudService(username, password,
+                                       cookie_directory=cookie_dir,
+                                       authenticate=False)
+            if _partition:
+                self.api._setup_endpoint = (
+                    f"https://p{_partition}-setup.icloud.com/setup/ws/1"
+                )
+            self.api.authenticate()
             if self.api.requires_2fa:
                 if sys.stdin.isatty():
                     print("Two-factor authentication required.")

--- a/driver.py
+++ b/driver.py
@@ -670,6 +670,7 @@ class ICloudSyncEngine:
         upload_interval_seconds=30,
         remote_refresh_interval_seconds=300,
         warmup_workers=1,
+        sync_paths=None,
     ):
         self.api = api
         self.mirror = mirror
@@ -680,6 +681,11 @@ class ICloudSyncEngine:
         self.upload_interval_seconds = upload_interval_seconds
         self.remote_refresh_interval_seconds = remote_refresh_interval_seconds
         self.warmup_workers = max(1, int(warmup_workers))
+        # Normalise sync_paths: list of /-prefixed strings, or None = allow all
+        if sync_paths:
+            self.sync_paths = [p if p.startswith('/') else '/' + p for p in sync_paths]
+        else:
+            self.sync_paths = None
         self.executor = ThreadPoolExecutor(max_workers=self.warmup_workers, thread_name_prefix="warmup")
         self.stop_event = threading.Event()
         self.path_locks = {}
@@ -809,6 +815,8 @@ class ICloudSyncEngine:
         )
 
     def ensure_local_file(self, path):
+        if not self._path_allowed(path):
+            return
         entry = self.state.get_entry(path)
         if not entry or entry["type"] != "file" or entry["tombstone"]:
             return
@@ -1055,6 +1063,8 @@ class ICloudSyncEngine:
         self._schedule_download_with_delay(path, 0)
 
     def _schedule_download_with_delay(self, path, delay_seconds):
+        if not self._path_allowed(path):
+            return
         if self.stop_event.is_set() or self.is_shutdown:
             return
 
@@ -1401,6 +1411,15 @@ class ICloudSyncEngine:
             else dirname.rstrip("/") + "/" + f"{basename}.local-conflict-{stamp}"
         )
 
+    def _path_allowed(self, path):
+        """Return True if this path should be hydrated/downloaded."""
+        if self.sync_paths is None:
+            return True
+        for prefix in self.sync_paths:
+            if path == prefix or path.startswith(prefix + '/'):
+                return True
+        return False
+
     def _path_lock(self, path):
         with self.path_locks_lock:
             lock = self.path_locks.get(path)
@@ -1506,6 +1525,7 @@ class ICloudFS(Fuse):
         upload_interval_seconds,
         remote_refresh_interval_seconds,
         warmup_workers,
+        sync_paths=None,
     ):
         self.mirror = LocalMirror(cache_dir)
         state_path = os.path.join(cache_dir, "state.sqlite3")
@@ -1520,6 +1540,7 @@ class ICloudFS(Fuse):
             upload_interval_seconds=upload_interval_seconds,
             remote_refresh_interval_seconds=remote_refresh_interval_seconds,
             warmup_workers=warmup_workers,
+            sync_paths=sync_paths,
         )
         self.sync_engine.start()
 
@@ -1897,6 +1918,7 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
     upload_interval_seconds = int(config.get("upload_interval_seconds", 30))
     remote_refresh_interval_seconds = int(config.get("remote_refresh_interval_seconds", 300))
     warmup_workers = int(config.get("warmup_workers", 1))
+    sync_paths = config.get("sync_paths", None)  # list of iCloud paths to hydrate, None=all
 
     fs.init_icloud(username, password, cache_dir, cookie_dir)
     fs.init_local_cache(
@@ -1906,6 +1928,7 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
         upload_interval_seconds,
         remote_refresh_interval_seconds,
         warmup_workers,
+        sync_paths=sync_paths,
     )
 
     atexit.register(fs.shutdown)

--- a/driver.py
+++ b/driver.py
@@ -671,6 +671,7 @@ class ICloudSyncEngine:
         remote_refresh_interval_seconds=300,
         warmup_workers=1,
         sync_paths=None,
+        exclude_paths=None,
     ):
         self.api = api
         self.mirror = mirror
@@ -686,6 +687,11 @@ class ICloudSyncEngine:
             self.sync_paths = [p if p.startswith('/') else '/' + p for p in sync_paths]
         else:
             self.sync_paths = None
+        # Normalise exclude_paths: deny-list applied before sync_paths
+        if exclude_paths:
+            self.exclude_paths = [p if p.startswith('/') else '/' + p for p in exclude_paths]
+        else:
+            self.exclude_paths = []
         self.executor = ThreadPoolExecutor(max_workers=self.warmup_workers, thread_name_prefix="warmup")
         self.stop_event = threading.Event()
         self.path_locks = {}
@@ -1418,7 +1424,22 @@ class ICloudSyncEngine:
         )
 
     def _path_allowed(self, path):
-        """Return True if this path should be hydrated/downloaded."""
+        """Return True if this path should be hydrated/downloaded.
+
+        Rules (evaluated in order):
+          1. exclude_paths deny-list — any matching prefix blocks hydration,
+             regardless of sync_paths.  This lets you carve out large
+             subdirectories from an otherwise-allowed sync_path.
+          2. sync_paths allow-list — if set, only matching prefixes are
+             hydrated.  None means allow all (minus exclusions).
+        """
+        # 1. Deny-list check first
+        if self.exclude_paths:
+            for prefix in self.exclude_paths:
+                if path == prefix or path.startswith(prefix + '/'):
+                    return False
+
+        # 2. Allow-list check
         if self.sync_paths is None:
             return True
         for prefix in self.sync_paths:
@@ -1554,6 +1575,7 @@ class ICloudFS(Fuse):
         remote_refresh_interval_seconds,
         warmup_workers,
         sync_paths=None,
+        exclude_paths=None,
     ):
         self.mirror = LocalMirror(cache_dir)
         state_path = os.path.join(cache_dir, "state.sqlite3")
@@ -1575,6 +1597,7 @@ class ICloudFS(Fuse):
             remote_refresh_interval_seconds=remote_refresh_interval_seconds,
             warmup_workers=warmup_workers,
             sync_paths=sync_paths,
+            exclude_paths=exclude_paths,
         )
         self.sync_engine.start()
 
@@ -1980,7 +2003,8 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
     upload_interval_seconds = int(config.get("upload_interval_seconds", 30))
     remote_refresh_interval_seconds = int(config.get("remote_refresh_interval_seconds", 300))
     warmup_workers = int(config.get("warmup_workers", 1))
-    sync_paths = config.get("sync_paths", None)  # list of iCloud paths to hydrate, None=all
+    sync_paths = config.get("sync_paths", None)      # list of iCloud paths to hydrate, None=all
+    exclude_paths = config.get("exclude_paths", None) # deny-list applied before sync_paths
 
     # When running under systemd (no TTY) we never want a failed auth to crash
     # the process — that would trigger Restart=on-failure and hammer Apple's
@@ -1996,6 +2020,7 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
         remote_refresh_interval_seconds,
         warmup_workers,
         sync_paths=sync_paths,
+        exclude_paths=exclude_paths,
     )
 
     atexit.register(fs.shutdown)

--- a/driver.py
+++ b/driver.py
@@ -2037,6 +2037,51 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
     # lockout threshold.  require_session=True is still the right default for
     # interactive invocations (e.g. debugging from a terminal with -f).
     interactive = sys.stdin.isatty()
+
+    # Register signal handlers BEFORE init_local_cache() so they are live
+    # during the reconcile pass (~75s).  Without this, SIGUSR1 arriving during
+    # reconcile uses Python's default handler which kills the process.
+    atexit.register(fs.shutdown)
+
+    def handle_shutdown(signum, frame):
+        logger.info("Received signal %s, shutting down background sync", signum)
+        fs.shutdown()
+        raise SystemExit(0)
+
+    # SIGUSR1 — on-demand sync trigger (used by 'icloudctl sync')
+    # Queues a one-shot remote crawl in a background thread so the signal
+    # handler returns immediately and FUSE keeps serving requests.
+    # If sync_engine is not ready yet (still reconciling), queues it to run
+    # once the engine is available.
+    def handle_sigusr1(signum, frame):
+        def _one_shot():
+            # Wait up to 120s for the sync engine to be ready after startup
+            deadline = time.time() + 120
+            while fs.sync_engine is None and time.time() < deadline:
+                time.sleep(1)
+            if fs.sync_engine is None:
+                logger.warning("SIGUSR1: sync engine not available (unauthenticated or startup failed)")
+                return
+            logger.info("SIGUSR1: starting on-demand sync")
+            try:
+                fs.sync_engine.initial_scan()
+                logger.info("SIGUSR1: on-demand sync complete")
+            except Exception as exc:
+                logger.error("SIGUSR1: on-demand sync failed: %s", exc)
+            finally:
+                # Write completion marker so icloudctl sync can detect done.
+                state_dir = os.path.expanduser("~/.local/state/icloud-linux")
+                os.makedirs(state_dir, exist_ok=True)
+                marker = os.path.join(state_dir, "sync_done")
+                with open(marker, "w") as fh:
+                    fh.write(str(time.time()))
+
+        threading.Thread(target=_one_shot, name="icloud-on-demand-sync", daemon=True).start()
+
+    signal.signal(signal.SIGTERM, handle_shutdown)
+    signal.signal(signal.SIGINT, handle_shutdown)
+    signal.signal(signal.SIGUSR1, handle_sigusr1)
+
     fs.init_icloud(username, password, cache_dir, cookie_dir, require_session=interactive)
     fs.init_local_cache(
         cache_dir,
@@ -2049,42 +2094,6 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
         exclude_paths=exclude_paths,
         auto_sync=auto_sync,
     )
-
-    atexit.register(fs.shutdown)
-
-    def handle_shutdown(signum, frame):
-        logger.info("Received signal %s, shutting down background sync", signum)
-        fs.shutdown()
-        raise SystemExit(0)
-
-    # SIGUSR1 — on-demand sync trigger (used by 'icloudctl sync')
-    # Runs a one-shot remote crawl + upload pass in a background thread so the
-    # signal handler returns immediately and FUSE keeps serving requests.
-    def handle_sigusr1(signum, frame):
-        if fs.sync_engine is None:
-            logger.warning("SIGUSR1: sync engine not running (unauthenticated?)")
-            return
-        logger.info("SIGUSR1: starting on-demand sync")
-
-        def _one_shot():
-            try:
-                fs.sync_engine.initial_scan()
-                logger.info("SIGUSR1: on-demand sync complete")
-            except Exception as exc:
-                logger.error("SIGUSR1: on-demand sync failed: %s", exc)
-            finally:
-                # Write a completion marker so icloudctl sync can detect done.
-                state_dir = os.path.expanduser("~/.local/state/icloud-linux")
-                os.makedirs(state_dir, exist_ok=True)
-                marker = os.path.join(state_dir, "sync_done")
-                with open(marker, "w") as fh:
-                    fh.write(str(time.time()))
-
-        threading.Thread(target=_one_shot, name="icloud-on-demand-sync", daemon=True).start()
-
-    signal.signal(signal.SIGTERM, handle_shutdown)
-    signal.signal(signal.SIGINT, handle_shutdown)
-    signal.signal(signal.SIGUSR1, handle_sigusr1)
 
     try:
         fs.main()

--- a/finish-setup.sh
+++ b/finish-setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# finish-setup.sh — Run this in YOUR OWN terminal to complete icloud-linux setup.
+# This script requires a D-Bus session (i.e., a normal desktop terminal).
+
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "======================================"
+echo " icloud-linux — Final Setup Steps"
+echo "======================================"
+echo ""
+echo "Step 1: Enter your Apple ID credentials"
+bash "$REPO_DIR/icloudctl" configure
+echo ""
+
+echo "Step 2: Authenticate (2FA — you'll get a code on your Apple device)"
+bash "$REPO_DIR/icloudctl" auth
+echo ""
+
+echo "Step 3: Register and start the background service"
+systemctl --user daemon-reload
+systemctl --user enable icloud.service
+systemctl --user start icloud.service
+echo ""
+
+echo "Step 4: Check status"
+systemctl --user --no-pager status icloud.service
+echo ""
+
+echo "======================================"
+echo " Done! iCloud Drive will be mounted at:"
+echo "   ~/iCloud"
+echo ""
+echo " NOTE: warmup_mode is set to 'lazy' — no files are downloaded"
+echo " until you explicitly access them. Your 100GB+ iCloud Drive"
+echo " will appear as a full folder tree, but only files you touch"
+echo " will use local disk space."
+echo ""
+echo " To copy ONLY your Downloads folder to /mnt/downloads:"
+echo ""
+echo "   # Wait ~5 min after start for the metadata index to build, then:"
+echo "   rsync -av --progress ~/iCloud/Downloads/ /mnt/downloads/"
+echo ""
+echo " To copy a single file:"
+echo "   cp ~/iCloud/Downloads/somefile.pdf /mnt/downloads/"
+echo ""
+echo " To check how much local disk the cache is using:"
+echo "   du -sh ~/.cache/icloud-linux/"
+echo ""
+echo " To clear the local cache (frees disk, re-downloads on next access):"
+echo "   cd ~/projects/icloud-linux && ./icloudctl clear-cache"
+echo "======================================"

--- a/fix_filenames.py
+++ b/fix_filenames.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+fix_filenames.py — sanitize filenames in the icloud-linux mirror cache
+for safe copying to CIFS/NAS destinations.
+
+Fixes:
+  - Backslash octal escapes (e.g. \374 -> ü)
+  - Backslash-escaped characters (e.g. \_ -> _)
+  - Bare backslashes (removed)
+  - Leading/trailing spaces per path component
+  - Characters illegal on CIFS/Windows: < > : " | ? *
+    (replaced with a visually similar safe character or removed)
+
+Updates the SQLite state DB so the icloud-linux driver stays in sync.
+
+Usage:
+    .venv/bin/python fix_filenames.py [/path/to/mirror/subdir]
+
+    Defaults to the full Downloads mirror if no path given.
+
+Options:
+    --dry-run   Print what would be renamed without doing anything
+"""
+
+import os, re, sys, sqlite3, argparse
+
+MIRROR_ROOT = os.path.expanduser('~/.cache/icloud-linux/mirror')
+DB_PATH     = os.path.expanduser('~/.cache/icloud-linux/state.sqlite3')
+
+# Characters illegal on CIFS (Windows) filesystems
+CIFS_ILLEGAL = r'<>:"|?*'
+CIFS_REPLACE = {
+    '<':  '(',
+    '>':  ')',
+    ':':  '-',
+    '"':  "'",
+    '|':  '-',
+    '?':  '',
+    '*':  '',
+}
+
+def clean_name(name):
+    """Return a CIFS-safe version of a filename component."""
+    # 1. Backslash octal escapes e.g. \374 -> ü
+    def replace_octal(m):
+        try:
+            return bytes([int(m.group(1), 8)]).decode('latin-1')
+        except Exception:
+            return m.group(0)
+    name = re.sub(r'\\([0-7]{3})', replace_octal, name)
+
+    # 2. Backslash + specific char e.g. \_ -> _
+    name = re.sub(r'\\(.)', r'\1', name)
+
+    # 3. CIFS-illegal characters
+    for ch, repl in CIFS_REPLACE.items():
+        name = name.replace(ch, repl)
+
+    # 4. Strip leading/trailing spaces and dots (illegal on Windows)
+    name = name.strip(' .')
+
+    # 5. Collapse multiple spaces
+    name = re.sub(r'  +', ' ', name)
+
+    return name
+
+def mirror_to_icloud_path(disk_path):
+    """Convert an absolute mirror path to the iCloud-relative path stored in DB."""
+    rel = disk_path[len(MIRROR_ROOT):]
+    return rel if rel else '/'
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('path', nargs='?',
+                        default=os.path.join(MIRROR_ROOT, 'Downloads'),
+                        help='Directory to scan (default: mirror/Downloads)')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Print renames without executing them')
+    args = parser.parse_args()
+
+    scan_root = os.path.abspath(args.path)
+    if not os.path.isdir(scan_root):
+        print(f'ERROR: not a directory: {scan_root}')
+        sys.exit(1)
+
+    print(f'Scanning: {scan_root}')
+    print(f'Dry run:  {args.dry_run}')
+    print()
+
+    db  = sqlite3.connect(DB_PATH)
+    cur = db.cursor()
+
+    renamed = skipped = errors = 0
+
+    for dirpath, dirnames, filenames in os.walk(scan_root, topdown=False):
+        for fname in filenames:
+            new_fname = clean_name(fname)
+            if new_fname == fname:
+                continue
+
+            old_path = os.path.join(dirpath, fname)
+            new_path = os.path.join(dirpath, new_fname)
+
+            old_db = mirror_to_icloud_path(old_path)
+            new_db = mirror_to_icloud_path(new_path)
+
+            print(f'  OLD: {fname}')
+            print(f'  NEW: {new_fname}')
+
+            if args.dry_run:
+                print('  (dry run - skipped)')
+                skipped += 1
+            else:
+                try:
+                    os.rename(old_path, new_path)
+                    rows = cur.execute(
+                        'UPDATE entries SET path=?, parent_path=? WHERE path=?',
+                        (new_db, os.path.dirname(new_db), old_db)
+                    ).rowcount
+                    db.commit()
+                    print(f'  -> OK  (DB rows: {rows})')
+                    renamed += 1
+                except Exception as e:
+                    print(f'  -> ERROR: {e}')
+                    errors += 1
+            print()
+
+        # Also rename directories themselves
+        for dname in dirnames:
+            new_dname = clean_name(dname)
+            if new_dname == dname:
+                continue
+            old_dpath = os.path.join(dirpath, dname)
+            new_dpath = os.path.join(dirpath, new_dname)
+            old_db = mirror_to_icloud_path(old_dpath)
+            new_db = mirror_to_icloud_path(new_dpath)
+            print(f'  DIR OLD: {dname}')
+            print(f'  DIR NEW: {new_dname}')
+            if not args.dry_run:
+                try:
+                    os.rename(old_dpath, new_dpath)
+                    # Update all entries under this dir
+                    cur.execute(
+                        "UPDATE entries SET path = replace(path, ?, ?), "
+                        "parent_path = replace(parent_path, ?, ?) "
+                        "WHERE path LIKE ? OR path = ?",
+                        (old_db + '/', new_db + '/',
+                         old_db + '/', new_db + '/',
+                         old_db + '/%', old_db)
+                    )
+                    db.commit()
+                    print(f'  -> DIR OK')
+                    renamed += 1
+                except Exception as e:
+                    print(f'  -> DIR ERROR: {e}')
+                    errors += 1
+            else:
+                skipped += 1
+            print()
+
+    db.close()
+
+    if args.dry_run:
+        print(f'Dry run complete: {skipped} would be renamed')
+    else:
+        if renamed == 0 and errors == 0:
+            print('No problematic filenames found.')
+        else:
+            print(f'Done: {renamed} renamed, {errors} errors')
+
+if __name__ == '__main__':
+    main()

--- a/fix_filenames.py
+++ b/fix_filenames.py
@@ -134,19 +134,32 @@ def main():
             new_dpath = os.path.join(dirpath, new_dname)
             old_db = mirror_to_icloud_path(old_dpath)
             new_db = mirror_to_icloud_path(new_dpath)
+            old_prefix = old_db.rstrip('/') + '/'
+            new_prefix = new_db.rstrip('/') + '/'
             print(f'  DIR OLD: {dname}')
             print(f'  DIR NEW: {new_dname}')
             if not args.dry_run:
                 try:
                     os.rename(old_dpath, new_dpath)
-                    # Update all entries under this dir
+                    # Update the directory entry itself
                     cur.execute(
-                        "UPDATE entries SET path = replace(path, ?, ?), "
-                        "parent_path = replace(parent_path, ?, ?) "
-                        "WHERE path LIKE ? OR path = ?",
-                        (old_db + '/', new_db + '/',
-                         old_db + '/', new_db + '/',
-                         old_db + '/%', old_db)
+                        "UPDATE entries SET path = ?, parent_path = ? WHERE path = ?",
+                        (new_db, os.path.dirname(new_db) or '/', old_db)
+                    )
+                    # Update all children using a safe prefix match.
+                    # We use SUBSTR to avoid clobbering sibling paths that
+                    # share a common prefix (the bug in the old replace() approach).
+                    prefix_len = len(old_prefix)
+                    cur.execute(
+                        """
+                        UPDATE entries
+                        SET path        = ? || SUBSTR(path,        ?),
+                            parent_path = ? || SUBSTR(parent_path, ?)
+                        WHERE path LIKE ?
+                        """,
+                        (new_prefix, prefix_len + 1,
+                         new_prefix, prefix_len + 1,
+                         old_prefix + '%')
                     )
                     db.commit()
                     print(f'  -> DIR OK')

--- a/hydrate.py
+++ b/hydrate.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+hydrate.py — force local hydration of all files under sync_paths,
+respecting the exclude_paths deny-list from config.yaml.
+
+Reads config.yaml for sync_paths and exclude_paths so the same rules
+that govern the FUSE driver apply here — single source of truth.
+
+Opens each unhydrated file through the FUSE mount (not the mirror cache)
+so the driver's lazy-download machinery does the actual pull.  Blocks
+until all eligible files are hydrated.  Safe to interrupt and re-run.
+
+Usage:
+  ./icloudctl hydrate [--config PATH] [--dry-run] [--verbose]
+  .venv/bin/python hydrate.py [--config PATH] [--dry-run] [--verbose]
+
+Exit codes:
+  0  All eligible files hydrated successfully
+  1  One or more files failed to hydrate (logged to stderr)
+  2  Configuration or mount error
+"""
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+import yaml
+
+
+# ── path filtering (mirrors ICloudSyncEngine._path_allowed) ──────────────────
+
+def _normalise(paths):
+    """Ensure all paths start with /."""
+    if not paths:
+        return []
+    return [p if p.startswith("/") else "/" + p for p in paths]
+
+
+def path_allowed(path, sync_paths, exclude_paths):
+    """Return True if this path should be hydrated.
+
+    Mirrors ICloudSyncEngine._path_allowed() exactly:
+      1. exclude_paths deny-list wins — matching prefix blocks hydration.
+      2. sync_paths allow-list — if set, only matching prefixes hydrate.
+         None means allow all (minus exclusions).
+    """
+    # 1. Deny-list
+    for prefix in exclude_paths:
+        if path == prefix or path.startswith(prefix + "/"):
+            return False
+
+    # 2. Allow-list
+    if sync_paths is None:
+        return True
+    for prefix in sync_paths:
+        if path == prefix or path.startswith(prefix + "/"):
+            return True
+    return False
+
+
+# ── config ────────────────────────────────────────────────────────────────────
+
+def load_config(config_path):
+    with open(config_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+# ── DB helpers ────────────────────────────────────────────────────────────────
+
+def get_unhydrated(db_path, sync_paths, exclude_paths):
+    """Return list of (icloud_path, size) for all eligible unhydrated files."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT path, size FROM entries
+        WHERE type = 'file'
+          AND hydrated = 0
+          AND tombstone = 0
+        ORDER BY path
+        """
+    ).fetchall()
+    conn.close()
+    return [
+        (row["path"], row["size"])
+        for row in rows
+        if path_allowed(row["path"], sync_paths, exclude_paths)
+    ]
+
+
+def get_hydrated_count(db_path, sync_paths, exclude_paths):
+    """Count already-hydrated eligible files (for progress display)."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT path FROM entries
+        WHERE type = 'file'
+          AND hydrated = 1
+          AND tombstone = 0
+        """
+    ).fetchall()
+    conn.close()
+    return sum(
+        1 for row in rows
+        if path_allowed(row["path"], sync_paths, exclude_paths)
+    )
+
+
+# ── hydration ─────────────────────────────────────────────────────────────────
+
+def hydrate_file(mount_path, icloud_path, verbose):
+    """Open the file through the FUSE mount to trigger hydration.
+
+    We read just the first byte — enough to force the driver to pull the
+    full file before returning.  For zero-byte files an open() alone is
+    sufficient.
+    """
+    local = mount_path.rstrip("/") + icloud_path
+    try:
+        with open(local, "rb") as f:
+            f.read(1)
+        return True
+    except OSError as exc:
+        if verbose:
+            print(f"  WARN: {icloud_path}: {exc}", file=sys.stderr)
+        return False
+
+
+def format_size(n_bytes):
+    for unit in ("B", "KB", "MB", "GB"):
+        if n_bytes < 1024:
+            return f"{n_bytes:.1f} {unit}"
+        n_bytes /= 1024
+    return f"{n_bytes:.1f} TB"
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Force local hydration of all eligible iCloud files."
+    )
+    parser.add_argument(
+        "--config",
+        default=os.path.expanduser("~/.config/icloud-linux/config.yaml"),
+        help="Path to config.yaml (default: ~/.config/icloud-linux/config.yaml)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be hydrated without downloading anything.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print each file as it is hydrated.",
+    )
+    args = parser.parse_args()
+
+    # ── load config ──────────────────────────────────────────────────────────
+    if not os.path.exists(args.config):
+        print(f"ERROR: config not found: {args.config}", file=sys.stderr)
+        sys.exit(2)
+
+    cfg = load_config(args.config)
+    sync_paths    = _normalise(cfg.get("sync_paths"))    or None  # None = allow all
+    exclude_paths = _normalise(cfg.get("exclude_paths") or [])
+    cache_dir     = os.path.expanduser(cfg.get("cache_dir", "~/.cache/icloud-linux"))
+    db_path       = os.path.join(cache_dir, "state.sqlite3")
+
+    # Mount dir: prefer config key, fall back to icloud.env, then default ~/iCloud
+    mount_dir = cfg.get("mount_dir")
+    if not mount_dir:
+        env_file = os.path.expanduser("~/.config/icloud-linux/icloud.env")
+        if os.path.exists(env_file):
+            with open(env_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("ICLOUD_MOUNT="):
+                        mount_dir = line.split("=", 1)[1].strip().strip('"')
+                        break
+    if not mount_dir:
+        mount_dir = os.path.expanduser("~/iCloud")
+    mount_dir = os.path.expanduser(mount_dir)
+
+    # ── validate mount ───────────────────────────────────────────────────────
+    if not os.path.isdir(mount_dir):
+        print(f"ERROR: mount point not found: {mount_dir}", file=sys.stderr)
+        print("Is the icloud service running?  Try: icloudctl start", file=sys.stderr)
+        sys.exit(2)
+
+    # Quick sanity check — the mount should be a FUSE mount, not just an
+    # empty directory.  We check by seeing if the root lists anything.
+    try:
+        os.listdir(mount_dir)
+    except OSError as exc:
+        print(f"ERROR: cannot read mount at {mount_dir}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    if not os.path.exists(db_path):
+        print(f"ERROR: state DB not found: {db_path}", file=sys.stderr)
+        sys.exit(2)
+
+    # ── report config ────────────────────────────────────────────────────────
+    print("icloud-linux hydrate")
+    print(f"  Config:       {args.config}")
+    print(f"  Mount:        {mount_dir}")
+    print(f"  DB:           {db_path}")
+    print(f"  sync_paths:   {sync_paths or '(all)'}")
+    print(f"  exclude_paths:{exclude_paths or '(none)'}")
+    print()
+
+    # ── find unhydrated files ────────────────────────────────────────────────
+    print("Scanning state DB for unhydrated files...", end=" ", flush=True)
+    pending = get_unhydrated(db_path, sync_paths, exclude_paths)
+    already_done = get_hydrated_count(db_path, sync_paths, exclude_paths)
+    total_eligible = len(pending) + already_done
+    total_bytes = sum(size for _, size in pending)
+
+    print(f"done.")
+    print(f"  Eligible files:  {total_eligible:,}")
+    print(f"  Already local:   {already_done:,}")
+    print(f"  Need download:   {len(pending):,}  ({format_size(total_bytes)})")
+    print()
+
+    if not pending:
+        print("All eligible files are already hydrated. Nothing to do.")
+        sys.exit(0)
+
+    if args.dry_run:
+        print("DRY RUN — files that would be hydrated:")
+        for path, size in pending:
+            print(f"  {format_size(size):>10}  {path}")
+        sys.exit(0)
+
+    # ── hydrate ──────────────────────────────────────────────────────────────
+    print(f"Starting hydration of {len(pending):,} files...")
+    print("(This will block until all files are downloaded.  Ctrl-C to pause.)\n")
+
+    completed = 0
+    failed = 0
+    start = time.time()
+    last_report = start
+
+    for i, (icloud_path, size) in enumerate(pending, 1):
+        if args.verbose:
+            print(f"  [{i}/{len(pending)}] {icloud_path} ({format_size(size)})")
+
+        ok = hydrate_file(mount_dir, icloud_path, args.verbose)
+        if ok:
+            completed += 1
+        else:
+            failed += 1
+
+        # Progress report every 25 files or every 30 seconds
+        now = time.time()
+        if (i % 25 == 0 or i == len(pending) or now - last_report >= 30):
+            elapsed = now - start
+            rate = completed / elapsed if elapsed > 0 else 0
+            eta = (len(pending) - i) / rate if rate > 0 else 0
+            eta_str = f"{int(eta)}s" if eta < 120 else f"{int(eta/60)}m {int(eta%60)}s"
+            print(
+                f"  Progress: {i}/{len(pending)} files"
+                f"  ({completed} ok, {failed} failed)"
+                f"  elapsed {int(elapsed)}s"
+                f"  ETA ~{eta_str}"
+            )
+            last_report = now
+
+    elapsed = time.time() - start
+    print()
+    print(f"Hydration complete in {int(elapsed)}s.")
+    print(f"  Succeeded: {completed:,}")
+    print(f"  Failed:    {failed:,}")
+
+    if failed:
+        print(
+            f"\nWARNING: {failed} file(s) failed to hydrate. "
+            "Re-run to retry, or check logs with: icloudctl logs",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hydrate_dir.py
+++ b/hydrate_dir.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Standalone hydration script for icloud-linux.
+Downloads all unhydrated files under a given iCloud path prefix
+using drive.get_file(docwsid, zone) - bypasses FUSE entirely.
+
+Usage:
+    .venv/bin/python hydrate_dir.py [/Downloads/Move2]
+"""
+
+import hashlib, logging, os, sqlite3, sys, tempfile, shutil, time
+import yaml, requests as _req
+from pyicloud import PyiCloudService
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("hydrate")
+
+CONFIG_PATH = os.path.expanduser("~/.config/icloud-linux/config.yaml")
+config      = yaml.safe_load(open(CONFIG_PATH))
+
+CACHE_DIR   = os.path.expanduser(config["cache_dir"])
+MIRROR_ROOT = os.path.join(CACHE_DIR, "mirror")
+DB_PATH     = os.path.join(CACHE_DIR, "state.sqlite3")
+COOKIE_DIR  = os.path.expanduser(config.get("cookie_dir", "~/.config/icloud-linux/cookies"))
+USERNAME    = config["username"]
+PASSWORD    = config["password"]
+
+TARGET = sys.argv[1] if len(sys.argv) > 1 else "/Downloads/Move2"
+if not TARGET.startswith("/"):
+    TARGET = "/" + TARGET
+
+log.info("Target: %s", TARGET)
+
+# ── Auth ─────────────────────────────────────────────────────────────────────
+log.info("Authenticating as %s ...", USERNAME)
+_r = _req.post("https://setup.icloud.com/setup/ws/1/validate", json={})
+_partition = _r.headers.get("x-apple-user-partition")
+api = PyiCloudService(USERNAME, PASSWORD,
+                      cookie_directory=COOKIE_DIR, authenticate=False)
+if _partition:
+    api._setup_endpoint = f"https://p{_partition}-setup.icloud.com/setup/ws/1"
+api.authenticate()
+if api.requires_2fa or api.requires_2sa:
+    raise RuntimeError("2FA required - run ./icloudctl auth first")
+log.info("Auth OK")
+
+# ── Load unhydrated rows ──────────────────────────────────────────────────────
+db  = sqlite3.connect(DB_PATH)
+db.row_factory = sqlite3.Row
+cur = db.cursor()
+
+rows = cur.execute("""
+    SELECT path, remote_docwsid, remote_zone, size, mtime
+    FROM   entries
+    WHERE  (path = ? OR path LIKE ?)
+      AND  type='file' AND hydrated=0 AND tombstone=0
+      AND  remote_docwsid IS NOT NULL
+    ORDER  BY size ASC
+""", (TARGET, TARGET + "/%")).fetchall()
+
+total = len(rows)
+log.info("%d unhydrated files to download", total)
+if total == 0:
+    log.info("Nothing to do")
+    sys.exit(0)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+def write_atomic(dest, data, mtime=None):
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(dest))
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        if mtime:
+            os.utime(tmp, (mtime, mtime))
+        shutil.move(tmp, dest)
+    except Exception:
+        try: os.unlink(tmp)
+        except OSError: pass
+        raise
+
+def mark_hydrated(path, data):
+    ck = hashlib.sha256(data).hexdigest()
+    cur.execute("UPDATE entries SET hydrated=1, local_sha256=?, size=? WHERE path=?",
+                (ck, len(data), path))
+    db.commit()
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+ok = failed = skipped = 0
+t0 = time.time()
+
+for i, row in enumerate(rows, 1):
+    path      = row["path"]
+    docwsid   = row["remote_docwsid"]
+    zone      = row["remote_zone"] or "com.apple.CloudDocs"
+    size      = row["size"] or 0
+    mtime     = row["mtime"]
+    dest      = os.path.join(MIRROR_ROOT, path.lstrip("/"))
+
+    # Already fully on disk - just mark hydrated
+    if os.path.exists(dest) and os.path.getsize(dest) == size and size > 80:
+        data = open(dest, "rb").read()
+        mark_hydrated(path, data)
+        skipped += 1
+        if i % 100 == 0 or i == total:
+            log.info("[%d/%d] already-ok (skipped dl): %s", i, total, os.path.basename(path))
+        continue
+
+    for attempt in range(1, 4):
+        try:
+            resp    = api.drive.get_file(docwsid, zone=zone, stream=True)
+            content = resp.raw.read()
+            write_atomic(dest, content, mtime)
+            mark_hydrated(path, content)
+            ok += 1
+            elapsed = time.time() - t0
+            rate    = ok / elapsed if elapsed > 0 else 0
+            eta     = (total - i) / rate if rate > 0 else 0
+            log.info("[%d/%d] OK %s (%d B)  %.1f/min  ETA %ds",
+                     i, total, os.path.basename(path), len(content), rate*60, eta)
+            break
+        except KeyboardInterrupt:
+            log.info("Interrupted. ok=%d failed=%d skipped=%d", ok, failed, skipped)
+            db.close(); sys.exit(1)
+        except Exception as exc:
+            log.warning("[%d/%d] attempt %d failed for %s: %s", i, total, attempt, path, exc)
+            if attempt < 3:
+                time.sleep(3 * attempt)
+            else:
+                log.error("[%d/%d] GIVING UP: %s", i, total, path)
+                failed += 1
+
+db.close()
+log.info("Done in %.0fs — downloaded=%d already-ok=%d failed=%d",
+         time.time()-t0, ok, skipped, failed)

--- a/icloudctl
+++ b/icloudctl
@@ -157,7 +157,7 @@ EOF
 cmd_auth() {
   ensure_venv
   create_config_if_missing
-  "$REPO_DIR/.venv/bin/python" "$REPO_DIR/auth.py" "$CONFIG_FILE"
+  "$REPO_DIR/.venv/bin/python" "$REPO_DIR/auth.py" "$CONFIG_FILE" "$@"
 }
 
 cmd_start() { cleanup_mountpoint "${1:-}"; systemctl --user start icloud.service; systemctl --user --no-pager status icloud.service; }
@@ -241,7 +241,10 @@ Commands:
   quickstart [mount_dir]   One-command guided setup
   init [mount_dir]         Initialize venv/config/service files
   configure [email]        Write config.yaml with credentials
-  auth                     Run interactive 2FA bootstrap
+  auth [--force-sms] [--debug] [--trust-token TOKEN]
+                           Run interactive 2FA bootstrap.
+                           --force-sms bypasses push delivery (iOS 26 beta workaround)
+                           --debug prints Apple's reported auth mode for diagnosis
   clear-cache              Remove local mirror/state and rebuild on next start
   start|stop|restart       Service control
   status                   Show service status
@@ -258,7 +261,7 @@ main() {
     quickstart) cmd_quickstart "$@" ;;
     init) cmd_init "$@" ;;
     configure) cmd_configure "$@" ;;
-    auth) cmd_auth ;;
+    auth) cmd_auth "$@" ;;
     clear-cache) cmd_clear_cache ;;
     start) cmd_start ;;
     stop) cmd_stop ;;

--- a/icloudctl
+++ b/icloudctl
@@ -170,6 +170,11 @@ cmd_hydrate() {
   "$REPO_DIR/.venv/bin/python" "$REPO_DIR/hydrate.py" --config "$CONFIG_FILE" "$@"
 }
 
+cmd_sync() {
+  ensure_venv
+  "$REPO_DIR/.venv/bin/python" "$REPO_DIR/sync.py" "$@"
+}
+
 cmd_clear_cache() {
   local was_active=0
   systemctl --user is-active --quiet icloud.service && was_active=1 || true
@@ -254,6 +259,10 @@ Commands:
                            Block until all eligible files are downloaded locally.
                            Honors sync_paths and exclude_paths from config.
                            Use before copy tasks to ensure files are fully local.
+  sync [--timeout SEC] [--quiet]
+                           Trigger an on-demand remote sync in the running driver
+                           (sends SIGUSR1, waits for completion).  Useful when
+                           auto_sync: false is set in config.yaml.
   clear-cache              Remove local mirror/state and rebuild on next start
   start|stop|restart       Service control
   status                   Show service status
@@ -272,6 +281,7 @@ main() {
     configure) cmd_configure "$@" ;;
     auth) cmd_auth "$@" ;;
     hydrate) cmd_hydrate "$@" ;;
+    sync) cmd_sync "$@" ;;
     clear-cache) cmd_clear_cache ;;
     start) cmd_start ;;
     stop) cmd_stop ;;

--- a/icloudctl
+++ b/icloudctl
@@ -165,6 +165,11 @@ cmd_stop() { systemctl --user stop icloud.service >/dev/null 2>&1 || true; clean
 cmd_restart() { systemctl --user stop icloud.service >/dev/null 2>&1 || true; cleanup_mountpoint "${1:-}"; systemctl --user start icloud.service; systemctl --user --no-pager status icloud.service; }
 cmd_status() { systemctl --user --no-pager status icloud.service; }
 cmd_logs() { journalctl --user -u icloud.service -f; }
+cmd_hydrate() {
+  ensure_venv
+  "$REPO_DIR/.venv/bin/python" "$REPO_DIR/hydrate.py" --config "$CONFIG_FILE" "$@"
+}
+
 cmd_clear_cache() {
   local was_active=0
   systemctl --user is-active --quiet icloud.service && was_active=1 || true
@@ -245,6 +250,10 @@ Commands:
                            Run interactive 2FA bootstrap.
                            --force-sms bypasses push delivery (iOS 26 beta workaround)
                            --debug prints Apple's reported auth mode for diagnosis
+  hydrate [--dry-run] [--verbose]
+                           Block until all eligible files are downloaded locally.
+                           Honors sync_paths and exclude_paths from config.
+                           Use before copy tasks to ensure files are fully local.
   clear-cache              Remove local mirror/state and rebuild on next start
   start|stop|restart       Service control
   status                   Show service status
@@ -262,6 +271,7 @@ main() {
     init) cmd_init "$@" ;;
     configure) cmd_configure "$@" ;;
     auth) cmd_auth "$@" ;;
+    hydrate) cmd_hydrate "$@" ;;
     clear-cache) cmd_clear_cache ;;
     start) cmd_start ;;
     stop) cmd_stop ;;

--- a/sync.py
+++ b/sync.py
@@ -25,7 +25,7 @@ import time
 
 STATE_DIR = os.path.expanduser("~/.local/state/icloud-linux")
 MARKER_FILE = os.path.join(STATE_DIR, "sync_done")
-DEFAULT_TIMEOUT = 300  # seconds
+DEFAULT_TIMEOUT = 900  # seconds (15 min — iCloud crawl of 19k+ entries takes several minutes)
 
 
 def get_driver_pid():

--- a/sync.py
+++ b/sync.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+sync.py — trigger a one-shot on-demand iCloud sync in the running driver.
+
+Sends SIGUSR1 to the running icloud.service process, then waits for the
+completion marker written by the driver when the crawl finishes.  Exits
+when the sync is done or if it times out.
+
+Usage:
+  ./icloudctl sync [--timeout SECONDS] [--quiet]
+  .venv/bin/python sync.py [--timeout SECONDS] [--quiet]
+
+Exit codes:
+  0  Sync completed successfully
+  1  Sync timed out or driver did not respond
+  2  Could not locate running driver process
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+
+STATE_DIR = os.path.expanduser("~/.local/state/icloud-linux")
+MARKER_FILE = os.path.join(STATE_DIR, "sync_done")
+DEFAULT_TIMEOUT = 300  # seconds
+
+
+def get_driver_pid():
+    """Return PID of the running icloud.service process, or None."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "--user", "show", "icloud.service", "--property=MainPID", "--value"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        pid_str = result.stdout.strip()
+        pid = int(pid_str)
+        return pid if pid > 0 else None
+    except (subprocess.CalledProcessError, ValueError):
+        return None
+
+
+def send_sigusr1(pid):
+    """Send SIGUSR1 to the driver process."""
+    import signal
+    os.kill(pid, signal.SIGUSR1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Trigger an on-demand iCloud sync in the running driver."
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"Seconds to wait for sync completion (default: {DEFAULT_TIMEOUT})",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress progress output.",
+    )
+    args = parser.parse_args()
+
+    def log(msg):
+        if not args.quiet:
+            print(msg, flush=True)
+
+    # ── find driver ──────────────────────────────────────────────────────────
+    pid = get_driver_pid()
+    if pid is None:
+        print("ERROR: icloud.service is not running. Start it with: icloudctl start", file=sys.stderr)
+        sys.exit(2)
+
+    log(f"icloud.service PID: {pid}")
+
+    # ── remove stale marker so we can detect a fresh completion ─────────────
+    try:
+        os.remove(MARKER_FILE)
+    except FileNotFoundError:
+        pass
+
+    # ── send signal ──────────────────────────────────────────────────────────
+    log("Sending sync signal to driver...")
+    try:
+        send_sigusr1(pid)
+    except ProcessLookupError:
+        print("ERROR: Driver process not found (PID may be stale).", file=sys.stderr)
+        sys.exit(2)
+    except PermissionError:
+        print("ERROR: Permission denied sending signal to driver.", file=sys.stderr)
+        sys.exit(2)
+
+    # ── wait for completion marker ───────────────────────────────────────────
+    log(f"Waiting for sync to complete (timeout: {args.timeout}s)...")
+    deadline = time.time() + args.timeout
+    poll_interval = 2
+
+    while time.time() < deadline:
+        if os.path.exists(MARKER_FILE):
+            # Read the timestamp inside to confirm it's a fresh marker
+            try:
+                with open(MARKER_FILE) as fh:
+                    ts = float(fh.read().strip())
+                # Allow 5s clock skew
+                if ts >= time.time() - (args.timeout + 5):
+                    elapsed = int(time.time() - (deadline - args.timeout))
+                    log(f"Sync complete in ~{elapsed}s.")
+                    sys.exit(0)
+            except (ValueError, OSError):
+                pass
+        time.sleep(poll_interval)
+
+    print(
+        f"ERROR: Sync did not complete within {args.timeout}s. "
+        "Check logs with: icloudctl logs",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
driver.py: detect Apple account shard via the setup/ws/1/validate endpoint before authenticating. Patches api._setup_endpoint to p{N}-setup.icloud.com to prevent 421 errors for users whose Apple ID lives on a non-default partition.

auth.py: rewrite to include the same partition detection, add a --trust-token flag for injecting a browser-extracted HSA2 trust token directly into the pyicloud session. This allows authentication to succeed when 2FA push notifications are not delivered to Apple devices (reproduced on iOS 26 beta).

finish-setup.sh: interactive helper script for first-time credential configuration and systemd user service registration.