### PR TITLE
Add on-demand remote refresh command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help quickstart init configure auth start stop restart status logs doctor uninstall
+.PHONY: help quickstart init configure auth start stop restart refresh status logs doctor uninstall
 
 help:
 	@echo "Targets:"
@@ -6,7 +6,7 @@ help:
 	@echo "  make init         # init venv/config/service"
 	@echo "  make configure    # write credentials config"
 	@echo "  make auth         # run interactive 2FA bootstrap"
-	@echo "  make start|stop|restart|status|logs|doctor|uninstall"
+	@echo "  make start|stop|restart|refresh|status|logs|doctor|uninstall"
 
 quickstart:
 	./icloudctl quickstart
@@ -28,6 +28,9 @@ stop:
 
 restart:
 	./icloudctl restart
+
+refresh:
+	./icloudctl refresh
 
 status:
 	./icloudctl status

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ If Apple expires your session, run:
 ./icloudctl start
 ./icloudctl stop
 ./icloudctl restart
+./icloudctl refresh
 ./icloudctl status
 ./icloudctl logs
 ./icloudctl doctor
@@ -129,6 +130,7 @@ What they do:
 - `start`: starts the background user service
 - `stop`: stops the service and unmounts the folder
 - `restart`: restarts the service cleanly
+- `refresh`: asks the running service to crawl remote iCloud Drive metadata now
 - `status`: shows whether the service is running
 - `logs`: tails the service logs
 - `doctor`: checks common setup issues

--- a/driver.py
+++ b/driver.py
@@ -682,6 +682,7 @@ class ICloudSyncEngine:
         self.warmup_workers = max(1, int(warmup_workers))
         self.executor = ThreadPoolExecutor(max_workers=self.warmup_workers, thread_name_prefix="warmup")
         self.stop_event = threading.Event()
+        self.refresh_now_event = threading.Event()
         self.path_locks = {}
         self.path_locks_lock = threading.Lock()
         self.scheduled_downloads = set()
@@ -730,6 +731,7 @@ class ICloudSyncEngine:
                 return
             self.is_shutdown = True
             self.stop_event.set()
+            self.refresh_now_event.set()
             with self.downloads_lock:
                 timers = list(self.download_retry_timers.values())
                 self.download_retry_timers.clear()
@@ -1166,21 +1168,30 @@ class ICloudSyncEngine:
             except Exception as exc:
                 self.logger.error("Upload loop failed: %s", exc)
 
+    def request_remote_refresh(self):
+        self._log_sync("refresh-requested")
+        self.refresh_now_event.set()
+
+    def _run_remote_refresh(self, reason):
+        try:
+            self._log_sync("refresh-start", reason=reason)
+            snapshot = self._crawl_remote_snapshot()
+            self._apply_remote_snapshot(snapshot)
+            self._log_sync("refresh-complete", reason=reason)
+        except Exception as exc:
+            self.logger.error("Remote refresh failed (%s): %s", reason, exc)
+
     def _refresh_loop(self):
         immediate = self.has_persistent_cache()
         if immediate:
-            try:
-                self.logger.info("Starting background remote refresh from persistent cache")
-                snapshot = self._crawl_remote_snapshot()
-                self._apply_remote_snapshot(snapshot)
-            except Exception as exc:
-                self.logger.error("Initial background refresh failed: %s", exc)
-        while not self.stop_event.wait(self.remote_refresh_interval_seconds):
-            try:
-                snapshot = self._crawl_remote_snapshot()
-                self._apply_remote_snapshot(snapshot)
-            except Exception as exc:
-                self.logger.error("Refresh loop failed: %s", exc)
+            self.logger.info("Starting background remote refresh from persistent cache")
+            self._run_remote_refresh("startup")
+        while not self.stop_event.is_set():
+            manual = self.refresh_now_event.wait(self.remote_refresh_interval_seconds)
+            self.refresh_now_event.clear()
+            if self.stop_event.is_set():
+                break
+            self._run_remote_refresh("manual" if manual else "scheduled")
 
     def sync_dirty_entries(self):
         dirty_entries = self.state.list_dirty_entries()
@@ -1436,6 +1447,12 @@ class ICloudFS(Fuse):
     def shutdown(self):
         if self.sync_engine is not None:
             self.sync_engine.shutdown()
+
+    def request_remote_refresh(self):
+        if self.sync_engine is None:
+            self.logger.warning("Remote refresh requested before sync engine was initialized")
+            return
+        self.sync_engine.request_remote_refresh()
 
     def init_icloud(self, username, password, cache_dir, cookie_dir=None):
         self.username = username
@@ -1903,8 +1920,14 @@ iCloud Linux: Mount iCloud Drive as a FUSE filesystem
         fs.shutdown()
         raise SystemExit(0)
 
+    def handle_refresh(signum, frame):
+        logger.info("Received signal %s, requesting remote metadata crawl", signum)
+        fs.request_remote_refresh()
+
     signal.signal(signal.SIGTERM, handle_shutdown)
     signal.signal(signal.SIGINT, handle_shutdown)
+    if hasattr(signal, "SIGUSR1"):
+        signal.signal(signal.SIGUSR1, handle_refresh)
 
     try:
         fs.main()

--- a/icloudctl
+++ b/icloudctl
@@ -13,6 +13,24 @@ MOUNT_DIR_DEFAULT="$HOME/iCloud"
 
 need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1"; exit 1; }; }
 
+reject_control_chars() {
+  local label="$1"
+  local value="$2"
+  if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+    echo "$label must not contain newlines"
+    exit 1
+  fi
+}
+
+systemd_quote_arg() {
+  local value="$1"
+  reject_control_chars "systemd argument" "$value"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//%/%%}
+  printf '"%s"' "$value"
+}
+
 ensure_dirs() {
   mkdir -p "$CONFIG_DIR" "$STATE_DIR" "$CACHE_DIR" "$SERVICE_DIR"
 }
@@ -35,6 +53,13 @@ create_config_if_missing() {
 
 write_service() {
   local mount_dir="$1"
+  local python_bin="$REPO_DIR/.venv/bin/python"
+  local driver_py="$REPO_DIR/driver.py"
+  local python_bin_q driver_py_q config_file_q mount_dir_q
+  python_bin_q="$(systemd_quote_arg "$python_bin")"
+  driver_py_q="$(systemd_quote_arg "$driver_py")"
+  config_file_q="$(systemd_quote_arg "$CONFIG_FILE")"
+  mount_dir_q="$(systemd_quote_arg "$mount_dir")"
   cat > "$SERVICE_FILE" <<EOF
 [Unit]
 Description=iCloud Linux FUSE filesystem (user)
@@ -43,14 +68,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/fusermount -uz $mount_dir
-ExecStop=-/usr/bin/fusermount -uz $mount_dir
-ExecStart=$REPO_DIR/.venv/bin/python $REPO_DIR/driver.py -f -c $CONFIG_FILE $mount_dir
+ExecStartPre=-/usr/bin/fusermount -uz $mount_dir_q
+ExecStop=-/usr/bin/fusermount -uz $mount_dir_q
+ExecStart=$python_bin_q $driver_py_q -f -c $config_file_q $mount_dir_q
 Restart=on-failure
 RestartSec=15
 TimeoutStopSec=10
 KillMode=control-group
-ExecStopPost=-/usr/bin/fusermount -uz $mount_dir
+ExecStopPost=-/usr/bin/fusermount -uz $mount_dir_q
 Environment=ICLOUD_LOG_PATH=%h/.local/state/icloud-linux/icloud.log
 
 [Install]
@@ -61,10 +86,11 @@ EOF
 write_env() {
   local mount_dir="${1:-$MOUNT_DIR_DEFAULT}"
   mkdir -p "$mount_dir"
-  cat > "$ENV_FILE" <<EOF
-ICLOUD_CONFIG=$CONFIG_FILE
-ICLOUD_MOUNT=$mount_dir
-EOF
+  reject_control_chars "mount dir" "$mount_dir"
+  {
+    printf 'ICLOUD_CONFIG=%q\n' "$CONFIG_FILE"
+    printf 'ICLOUD_MOUNT=%q\n' "$mount_dir"
+  } > "$ENV_FILE"
   chmod 600 "$ENV_FILE"
 }
 
@@ -165,6 +191,14 @@ cmd_stop() { systemctl --user stop icloud.service >/dev/null 2>&1 || true; clean
 cmd_restart() { systemctl --user stop icloud.service >/dev/null 2>&1 || true; cleanup_mountpoint "${1:-}"; systemctl --user start icloud.service; systemctl --user --no-pager status icloud.service; }
 cmd_status() { systemctl --user --no-pager status icloud.service; }
 cmd_logs() { journalctl --user -u icloud.service -f; }
+cmd_refresh() {
+  if ! systemctl --user is-active --quiet icloud.service; then
+    echo "icloud.service is not running. Start it with './icloudctl start' first."
+    exit 1
+  fi
+  systemctl --user kill --kill-whom=main --signal=SIGUSR1 icloud.service
+  echo "Requested remote metadata crawl. Watch progress with './icloudctl logs'."
+}
 cmd_clear_cache() {
   local was_active=0
   systemctl --user is-active --quiet icloud.service && was_active=1 || true
@@ -244,6 +278,7 @@ Commands:
   auth                     Run interactive 2FA bootstrap
   clear-cache              Remove local mirror/state and rebuild on next start
   start|stop|restart       Service control
+  refresh                  Trigger a remote metadata crawl now
   status                   Show service status
   logs                     Tail service logs
   doctor                   Check local setup health
@@ -263,6 +298,7 @@ main() {
     start) cmd_start ;;
     stop) cmd_stop ;;
     restart) cmd_restart ;;
+    refresh) cmd_refresh ;;
     status) cmd_status ;;
     logs) cmd_logs ;;
     doctor) cmd_doctor ;;

--- a/test_driver.py
+++ b/test_driver.py
@@ -298,6 +298,13 @@ class SyncEngineStartupTests(unittest.TestCase):
 
         self.assertNotIn("/docs/a.txt", self.engine.scheduled_downloads)
 
+    def test_request_remote_refresh_sets_wakeup_event(self):
+        self.assertFalse(self.engine.refresh_now_event.is_set())
+
+        self.engine.request_remote_refresh()
+
+        self.assertTrue(self.engine.refresh_now_event.is_set())
+
     def test_node_from_entry_reuses_persisted_file_metadata(self):
         shareid = {"share-zone": "abc"}
         node = self.engine._node_from_entry(


### PR DESCRIPTION
## Summary
- add ./icloudctl refresh to request an immediate remote metadata crawl from the running service
- wake the background refresh loop with SIGUSR1 instead of waiting for the scheduled interval
- document the command and add unit coverage for the refresh trigger
- quote generated systemd service paths so checkouts with spaces work correctly

## Tests
- .venv/bin/python -m unittest -v
- bash -n icloudctl